### PR TITLE
Fix startup/save compatibility and reduce runtime frame spikes

### DIFF
--- a/crates/siglus_assets/src/gameexe.rs
+++ b/crates/siglus_assets/src/gameexe.rs
@@ -135,6 +135,14 @@ impl GameexeEntry {
     }
 }
 
+// Normalize the query once, rather than allocating its components once per
+// candidate entry. Stage wipes query many OBJECT.USE flags consecutively.
+fn indexed_key_matches(key: &[String], prefix: &[String], index: usize) -> bool {
+    key.len() > prefix.len()
+        && key[..prefix.len()] == *prefix
+        && key[prefix.len()].parse::<usize>().ok() == Some(index)
+}
+
 fn unquote_token(s: &str) -> &str {
     let t = s.trim();
     if t.len() >= 2 && t.starts_with('"') && t.ends_with('"') {
@@ -223,20 +231,22 @@ impl GameexeConfig {
         // non-padded decimal string, otherwise table-backed subsystems silently
         // miss registered rows. Keep reverse iteration to preserve get_entry
         // "last definition wins" behavior.
+        let parts = normalized_key_parts(prefix);
         self.entries
             .iter()
             .rev()
-            .find(|e| e.key_index(prefix) == Some(index))
+            .find(|e| indexed_key_matches(&e.key_parts, &parts, index))
     }
 
     pub fn get_indexed_field(&self, prefix: &str, index: usize, field: &str) -> Option<&str> {
+        let parts = normalized_key_parts(prefix);
         let nf = normalize_key(field);
         self.entries
             .iter()
             .rev()
             .find(|e| {
-                e.key_index(prefix) == Some(index)
-                    && e.key_field_after_index(prefix) == Some(nf.as_str())
+                indexed_key_matches(&e.key_parts, &parts, index)
+                    && e.key_parts.get(parts.len() + 1) == Some(&nf)
             })
             .map(|e| e.value.as_str())
     }
@@ -247,13 +257,14 @@ impl GameexeConfig {
         index: usize,
         field: &str,
     ) -> Option<&str> {
+        let parts = normalized_key_parts(prefix);
         let nf = normalize_key(field);
         self.entries
             .iter()
             .rev()
             .find(|e| {
-                e.key_index(prefix) == Some(index)
-                    && e.key_field_after_index(prefix) == Some(nf.as_str())
+                indexed_key_matches(&e.key_parts, &parts, index)
+                    && e.key_parts.get(parts.len() + 1) == Some(&nf)
             })
             .map(|e| e.scalar_unquoted())
     }
@@ -454,6 +465,29 @@ mod tests {
         let cfg = GameexeConfig::from_text("#COLOR_TABLE.000 = 255, 255, 255\n");
         assert_eq!(cfg.get_indexed_value("COLOR_TABLE", 0), Some("255, 255, 255"));
         assert_eq!(cfg.get_indexed_unquoted("COLOR_TABLE", 0), Some("255"));
+    }
+
+    #[test]
+    fn indexed_fast_path_matches_legacy_lookup_and_last_definition_wins() {
+        let cfg = GameexeConfig::from_text(
+            "#OBJECT.000.USE = 0\n#OBJECT.0.USE = 1\n#OBJECT.001.USE = \"0\"\n\
+             #OBJECT.OTHER.USE = 9\n#OBJECT.2 = 8\n#OBJECT.002.USE.EXTRA = 7\n\
+             #BUTTON.ACTION.003.FILE = \"button\", 4\n#OBJECT.EXTRA.0.USE = 6\n",
+        );
+        for prefix in ["OBJECT", "# object ", "BUTTON . ACTION", "MISSING"] {
+            for index in 0..5 {
+                let old_entry = cfg.entries.iter().rev().find(|e| e.key_index(prefix) == Some(index));
+                assert_eq!(cfg.get_indexed_entry(prefix, index).map(|e| e.line_no), old_entry.map(|e| e.line_no));
+                for field in ["USE", " FILE ", "USE.EXTRA"] {
+                    let normalized = normalize_key(field);
+                    let old = cfg.entries.iter().rev().find(|e| e.key_index(prefix) == Some(index)
+                        && e.key_field_after_index(prefix) == Some(normalized.as_str()));
+                    assert_eq!(cfg.get_indexed_field(prefix, index, field), old.map(|e| e.value.as_str()));
+                    assert_eq!(cfg.get_indexed_field_unquoted(prefix, index, field), old.map(|e| e.scalar_unquoted()));
+                }
+            }
+        }
+        assert_eq!(cfg.get_indexed_field("OBJECT", 0, "USE"), Some("1"));
     }
 }
 

--- a/crates/siglus_assets/src/scene_pck.rs
+++ b/crates/siglus_assets/src/scene_pck.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Context, Result};
 
@@ -179,7 +180,8 @@ pub struct ScenePck {
     pub header: PackScnHeader,
     pub scn_name_map: HashMap<String, usize>,
     pub inc_prop_name_map: HashMap<u32, String>,
-    pub inc_cmd_name_map: HashMap<u32, String>,
+    /// Immutable include-command names shared by scene execution cursors.
+    pub inc_cmd_name_map: Arc<HashMap<u32, String>>,
     pub inc_props: Vec<PackIncProp>,
     pub inc_cmds: Vec<PackIncCmd>,
 }
@@ -462,7 +464,7 @@ impl ScenePck {
             header,
             scn_name_map,
             inc_prop_name_map,
-            inc_cmd_name_map,
+            inc_cmd_name_map: Arc::new(inc_cmd_name_map),
             inc_props,
             inc_cmds,
         })
@@ -495,7 +497,16 @@ impl ScenePck {
         if let Ok(i) = name_or_index.parse::<usize>() {
             return Some(i);
         }
-        self.scn_name_map.get(name_or_index).copied()
+        self.scn_name_map.get(name_or_index).copied().or_else(|| {
+            // Script scene names are case-insensitive, just like named user
+            // commands. Compiled packs can store a lowercased name while a
+            // jump/farcall operand retains the source spelling.
+            self.scn_name_map
+                .iter()
+                .filter(|(name, _)| name.eq_ignore_ascii_case(name_or_index))
+                .map(|(_, no)| *no)
+                .min()
+        })
     }
 
     pub fn find_scene_name(&self, scn_no: usize) -> Option<&str> {
@@ -577,4 +588,39 @@ pub fn find_scene_pck_in_project(project_dir: &Path) -> Result<std::path::PathBu
         "scene_pck: Scene.pck not found under {}",
         project_dir.display()
     );
+}
+
+#[cfg(test)]
+mod scene_name_tests {
+    use super::*;
+
+    fn pack_with_names(names: &[(&str, usize)]) -> ScenePck {
+        ScenePck {
+            buf: Vec::new(),
+            header: PackScnHeader::read(&[0; 23 * 4], 0, false).unwrap(),
+            scn_name_map: names.iter().map(|(name, no)| (name.to_string(), *no)).collect(),
+            inc_prop_name_map: HashMap::new(),
+            inc_cmd_name_map: Arc::default(),
+            inc_props: Vec::new(),
+            inc_cmds: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn scene_lookup_matches_script_names_without_ascii_case() {
+        let pack = pack_with_names(&[("_title_menu", 2), ("背景_test", 3)]);
+        assert_eq!(pack.find_scene_no("_TITLE_Menu"), Some(2));
+        assert_eq!(pack.find_scene_no("背景_TEST"), Some(3));
+        assert_eq!(pack.find_scene_no("missing"), None);
+        assert_eq!(pack.find_scene_no("12"), Some(12));
+        assert_eq!(pack.find_scene_name(2), Some("_title_menu"));
+    }
+
+    #[test]
+    fn scene_lookup_preserves_exact_match_and_stable_fallback() {
+        let pack = pack_with_names(&[("Title", 7), ("TITLE", 4)]);
+        assert_eq!(pack.find_scene_no("Title"), Some(7));
+        assert_eq!(pack.find_scene_no("TITLE"), Some(4));
+        assert_eq!(pack.find_scene_no("title"), Some(4));
+    }
 }

--- a/crates/siglus_scene_vm/src/assets/g00.rs
+++ b/crates/siglus_scene_vm/src/assets/g00.rs
@@ -88,8 +88,9 @@ pub fn decode_g00(data: &[u8]) -> Result<DecodedG00> {
             let mut out = vec![0u8; decompress_length];
             lzss_decompress_24bit(&data[off..], &mut out).context("lzss_decompress_24bit")?;
 
-            // out is BGRA (alpha already 255). Convert to RGBA.
-            let rgba = bgra_to_rgba_inplace(out);
+            // Pixel-aligned literals/backreferences are emitted in RGBA
+            // directly, avoiding a second pass over the full background.
+            let rgba = out;
             Ok(DecodedG00 {
                 kind,
                 width,
@@ -322,14 +323,7 @@ fn real_live_type1_uncompress(compr: &[u8]) -> Result<(Vec<u8>, usize)> {
                 if act < offset {
                     bail!("type1 backref before start: act={act} offset={offset}");
                 }
-                for _ in 0..count {
-                    if act >= uncomprlen {
-                        break;
-                    }
-                    let v = out[act - offset];
-                    out[act] = v;
-                    act += 1;
-                }
+                copy_lzss_match(&mut out[..uncomprlen], &mut act, offset, count);
             }
 
             flag >>= 1;
@@ -342,6 +336,20 @@ fn real_live_type1_uncompress(compr: &[u8]) -> Result<(Vec<u8>, usize)> {
         let mut out = vec![0u8; payload_len];
         out.copy_from_slice(&compr[8..8 + payload_len]);
         Ok((out, payload_len))
+    }
+}
+
+// Copy only already-decoded bytes, doubling the available repeated prefix
+// when a match overlaps its destination. A single memmove is not sufficient
+// for LZSS overlap; byte-at-a-time Debug loops are unnecessarily expensive.
+fn copy_lzss_match(dst: &mut [u8], position: &mut usize, offset: usize, count: usize) {
+    debug_assert!(offset > 0 && *position >= offset && *position <= dst.len());
+    let source = *position - offset;
+    let end = *position + count.min(dst.len() - *position);
+    while *position < end {
+        let size = (*position - source).min(end - *position);
+        dst.copy_within(source..source + size, *position);
+        *position += size;
     }
 }
 
@@ -379,14 +387,7 @@ fn lzss_decompress(src: &[u8], dst: &mut [u8]) -> Result<()> {
                 if d < offset {
                     bail!("lzss backref before start: d={d} offset={offset}");
                 }
-                for _ in 0..count {
-                    if d >= dst.len() {
-                        break;
-                    }
-                    let v = dst[d - offset];
-                    dst[d] = v;
-                    d += 1;
-                }
+                copy_lzss_match(dst, &mut d, offset, count);
             }
             flags >>= 1;
         }
@@ -402,7 +403,8 @@ fn lzss_decompress(src: &[u8], dst: &mut [u8]) -> Result<()> {
 }
 
 fn lzss_decompress_24bit(src: &[u8], dst: &mut [u8]) -> Result<()> {
-    // the original implementation extractor emits BGRA (alpha byte set to 0xFF).
+    // Backreferences are pixel aligned, so the channel permutation can be
+    // applied once when a BGR literal enters the output, before any reuse.
     let mut s = 0usize;
     let mut d = 0usize;
     while d < dst.len() {
@@ -422,10 +424,9 @@ fn lzss_decompress_24bit(src: &[u8], dst: &mut [u8]) -> Result<()> {
                 if d + 4 > dst.len() {
                     bail!("lzss24 literal would overflow dst");
                 }
-                // movsw; movsb; then alpha=0xFF
-                dst[d] = src[s];
+                dst[d] = src[s + 2];
                 dst[d + 1] = src[s + 1];
-                dst[d + 2] = src[s + 2];
+                dst[d + 2] = src[s];
                 dst[d + 3] = 0xFF;
                 d += 4;
                 s += 3;
@@ -444,14 +445,7 @@ fn lzss_decompress_24bit(src: &[u8], dst: &mut [u8]) -> Result<()> {
                 if d < offset_bytes {
                     bail!("lzss24 backref before start: d={d} offset={offset_bytes}");
                 }
-                for _ in 0..count_bytes {
-                    if d >= dst.len() {
-                        break;
-                    }
-                    let v = dst[d - offset_bytes];
-                    dst[d] = v;
-                    d += 1;
-                }
+                copy_lzss_match(dst, &mut d, offset_bytes, count_bytes);
             }
             flags >>= 1;
         }
@@ -464,6 +458,51 @@ fn lzss_decompress_24bit(src: &[u8], dst: &mut [u8]) -> Result<()> {
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod decode_fast_path_tests {
+    use super::*;
+
+    #[test]
+    fn block_backreferences_match_byte_copy_for_overlap_and_output_tail() {
+        for offset in 1..=32 {
+            for count in 1..=64 {
+                for tail in [1, 7, 32, 64] {
+                    let mut expected = vec![0; 32 + tail];
+                    for (i, byte) in expected[..32].iter_mut().enumerate() { *byte = (i * 73) as u8; }
+                    let mut actual = expected.clone();
+                    let mut old_pos = 32;
+                    for _ in 0..count {
+                        if old_pos >= expected.len() { break; }
+                        expected[old_pos] = expected[old_pos - offset];
+                        old_pos += 1;
+                    }
+                    let mut new_pos = 32;
+                    copy_lzss_match(&mut actual, &mut new_pos, offset, count);
+                    assert_eq!((new_pos, actual), (old_pos, expected), "offset={offset}, count={count}, tail={tail}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn type_zero_literals_and_overlapping_repeats_emit_rgba() {
+        // One BGR literal followed by a 1-pixel-offset, 3-pixel match.
+        let mut file = vec![0, 4, 0, 1, 0];
+        file.extend_from_slice(&14u32.to_le_bytes());
+        file.extend_from_slice(&16u32.to_le_bytes());
+        file.extend_from_slice(&[1, 10, 20, 30, 0x12, 0]);
+        assert_eq!(decode_g00(&file).unwrap().frames[0].rgba, [30, 20, 10, 255].repeat(4));
+    }
+
+    #[test]
+    fn lzss_match_validation_still_rejects_invalid_offsets_and_truncation() {
+        assert!(lzss_decompress(&[0, 0, 0], &mut [0; 8]).is_err());
+        assert!(lzss_decompress(&[0, 0x10, 0], &mut [0; 8]).is_err());
+        assert!(lzss_decompress(&[1, 3], &mut [0; 8]).is_err());
+        assert!(lzss_decompress_24bit(&[0, 0, 0], &mut [0; 8]).is_err());
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/siglus_scene_vm/src/audio/engine.rs
+++ b/crates/siglus_scene_vm/src/audio/engine.rs
@@ -1,10 +1,16 @@
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use crate::platform_time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
-use kira::sound::static_sound::{StaticSoundData, StaticSoundHandle};
-use kira::sound::{EndPosition, Region};
+#[cfg(target_arch = "wasm32")]
+use kira::sound::static_sound::{StaticSoundData as BgmSoundData, StaticSoundHandle as BgmSoundHandle};
+#[cfg(not(target_arch = "wasm32"))]
+type BgmSoundData = kira::sound::streaming::StreamingSoundData<kira::sound::FromFileError>;
+#[cfg(not(target_arch = "wasm32"))]
+type BgmSoundHandle = kira::sound::streaming::StreamingSoundHandle<kira::sound::FromFileError>;
+use kira::sound::{EndPosition, PlaybackPosition, Region};
 use kira::tween::Tween;
 use kira::Volume;
 use siglus_assets::gameexe::{decode_gameexe_dat_bytes, GameexeConfig, GameexeDecodeOptions};
@@ -218,8 +224,8 @@ struct BgmScriptEntry {
 
 #[derive(Debug, Default)]
 struct BgmPlayerSlot {
-    handle: Option<StaticSoundHandle>,
-    source_bytes: Option<Vec<u8>>,
+    handle: Option<BgmSoundHandle>,
+    source_bytes: Option<Arc<[u8]>>,
     source_format: Option<BgmPlaybackFormat>,
     sample_rate_hz: u32,
     total_samples: u64,
@@ -305,6 +311,32 @@ impl BgmPlayerSlot {
         self.loop_flag && self.restart_sample < self.end_sample
     }
 
+    fn playback_data(&self, effective_start: u64, amp: f64, fade_in_ms: i64) -> Result<BgmSoundData> {
+        let source = self.source_bytes.as_ref().context("BGM slot not prepared")?;
+        // Native Siglus supplies a stream to the BGM player. Kira's static
+        // loader instead decodes the entire track on the VM thread. Keep the
+        // encoded payload shared and let Kira's streaming worker decode it.
+        // The browser backend retains its static fallback.
+        let mut data = BgmSoundData::from_cursor(Cursor::new(Arc::clone(source)))
+            .context("kira: prepare BGM playback stream")?
+            .start_position(PlaybackPosition::Samples(effective_start as usize))
+            .slice(Region {
+                start: PlaybackPosition::Samples(0),
+                end: EndPosition::Custom(PlaybackPosition::Samples(self.end_sample as usize)),
+            })
+            .volume(Volume::Amplitude(amp));
+        if self.has_loop_region() {
+            data = data.loop_region(Region {
+                start: PlaybackPosition::Samples(self.restart_sample as usize),
+                end: EndPosition::Custom(PlaybackPosition::Samples(self.end_sample as usize)),
+            });
+        }
+        if fade_in_ms > 0 {
+            data = data.fade_in_tween(tween_ms(fade_in_ms));
+        }
+        Ok(data)
+    }
+
     fn play_pos_samples(&self) -> u64 {
         let elapsed = self.elapsed_samples();
         if self.has_loop_region() {
@@ -352,7 +384,7 @@ pub struct BgmEngine {
     current_name: Option<String>,
     current_player_id: Option<usize>,
     players: Vec<BgmPlayerSlot>,
-    retired: Vec<(StaticSoundHandle, Instant)>,
+    retired: Vec<(BgmSoundHandle, Instant)>,
     delay_deadline: Option<Instant>,
     delayed_fade_in_ms: i64,
     loop_flag: bool,
@@ -369,6 +401,23 @@ impl std::fmt::Debug for BgmEngine {
             .field("loop_flag", &self.loop_flag)
             .field("pause_flag", &self.pause_flag)
             .finish()
+    }
+}
+
+impl Drop for BgmEngine {
+    fn drop(&mut self) {
+        // Streaming decoders outlive their handles. Stop all slots (including
+        // retiring crossfades) while the owning AudioHub can still process the
+        // commands, so a scene restart/game close releases their workers.
+        let immediate = Tween { duration: Duration::ZERO, ..Tween::default() };
+        for slot in &mut self.players {
+            if let Some(handle) = slot.handle.as_mut() {
+                handle.stop(immediate);
+            }
+        }
+        for (handle, _) in &mut self.retired {
+            handle.stop(immediate);
+        }
     }
 }
 
@@ -626,7 +675,7 @@ impl BgmEngine {
 
         let slot = &mut self.players[slot_id];
         slot.reset_all();
-        slot.source_bytes = Some(decoded.bytes);
+        slot.source_bytes = Some(decoded.bytes.into());
         slot.source_format = Some(decoded.format);
         slot.sample_rate_hz = decoded.sample_rate;
         slot.total_samples = total_samples;
@@ -651,9 +700,9 @@ impl BgmEngine {
     ) -> Result<()> {
         let amp = self.total_gain_amplitude();
         let slot = &mut self.players[slot_id];
-        let Some(source) = slot.source_bytes.as_ref() else {
+        if slot.source_bytes.is_none() {
             return Err(anyhow!("BGM slot not prepared"));
-        };
+        }
 
         let mut effective_start = slot.start_sample;
         if effective_start >= slot.end_sample {
@@ -681,33 +730,14 @@ impl BgmEngine {
             return Ok(());
         }
 
-        let start_sec = if slot.sample_rate_hz == 0 {
-            0.0
-        } else {
-            effective_start as f64 / slot.sample_rate_hz as f64
-        };
-        let mut data = StaticSoundData::from_cursor(Cursor::new(source.clone()))
-            .context("kira: decode BGM playback bytes")?;
-        data = data.start_position(start_sec);
-        if slot.has_loop_region() {
-            let loop_region = Region {
-                start: (slot.restart_sample as f64 / slot.sample_rate_hz.max(1) as f64).into(),
-                end: EndPosition::Custom(
-                    (slot.end_sample as f64 / slot.sample_rate_hz.max(1) as f64).into(),
-                ),
-            };
-            data = data.loop_region(loop_region);
-        }
+        let data = slot.playback_data(effective_start, amp, if start_paused { 0 } else { fade_in_ms })?;
+        #[cfg(not(target_arch = "wasm32"))]
+        let mut handle = audio.play_streaming(TrackKind::Bgm, data)?;
+        #[cfg(target_arch = "wasm32")]
         let mut handle = audio.play_static(TrackKind::Bgm, data)?;
 
         if start_paused {
-            let _ = handle.set_volume(Volume::Amplitude(amp), Tween::default());
             let _ = handle.pause(Tween::default());
-        } else if fade_in_ms > 0 {
-            let _ = handle.set_volume(Volume::Amplitude(0.0), Tween::default());
-            let _ = handle.set_volume(Volume::Amplitude(amp), tween_ms(fade_in_ms));
-        } else {
-            let _ = handle.set_volume(Volume::Amplitude(amp), Tween::default());
         }
 
         slot.handle = Some(handle);
@@ -1006,6 +1036,12 @@ impl BgmEngine {
             return Ok(());
         };
 
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(err) = self.players[cur_id].handle.as_mut().and_then(|h| h.pop_error()) {
+            self.stop_current_internal(0)?;
+            return Err(err).context("kira: decode BGM stream");
+        }
+
         let pending = self.players[cur_id].pending;
         if let Some(pending) = pending {
             if now >= pending.at {
@@ -1114,4 +1150,142 @@ fn load_gameexe_config(project_dir: &Path) -> Option<GameexeConfig> {
     let opt = load_gameexe_decode_options(project_dir).ok()?;
     let (text, _report) = decode_gameexe_dat_bytes(&raw, &opt).ok()?;
     Some(GameexeConfig::from_text(&text))
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod streaming_tests {
+    use super::*;
+
+    fn wav_source() -> Arc<[u8]> {
+        let data_len = 48000u32 * 2;
+        let mut wav = Vec::new();
+        wav.extend_from_slice(b"RIFF");
+        wav.extend_from_slice(&(36 + data_len).to_le_bytes());
+        wav.extend_from_slice(b"WAVEfmt ");
+        wav.extend_from_slice(&16u32.to_le_bytes());
+        wav.extend_from_slice(&1u16.to_le_bytes());
+        wav.extend_from_slice(&1u16.to_le_bytes());
+        wav.extend_from_slice(&48000u32.to_le_bytes());
+        wav.extend_from_slice(&96000u32.to_le_bytes());
+        wav.extend_from_slice(&2u16.to_le_bytes());
+        wav.extend_from_slice(&16u16.to_le_bytes());
+        wav.extend_from_slice(b"data");
+        wav.extend_from_slice(&data_len.to_le_bytes());
+        wav.resize(44 + data_len as usize, 0);
+        wav.into()
+    }
+
+    #[test]
+    fn native_bgm_keeps_a_shared_stream_and_sample_accurate_loop_range() {
+        let source = wav_source();
+        let slot = BgmPlayerSlot {
+            source_bytes: Some(Arc::clone(&source)),
+            end_sample: 40000,
+            restart_sample: 12000,
+            loop_flag: true,
+            ..Default::default()
+        };
+        let data = slot.playback_data(6000, 0.5, 250).unwrap();
+        // The decoder still owns the encoded source instead of a fully decoded
+        // PCM allocation, and reopening does not clone the encoded byte buffer.
+        assert_eq!(Arc::strong_count(&source), 3);
+        assert_eq!(data.settings.start_position, PlaybackPosition::Samples(6000));
+        assert_eq!(data.slice, Some((0, 40000)));
+        assert_eq!(data.num_frames(), 40000);
+        assert_eq!(data.settings.loop_region, Some(Region {
+            start: PlaybackPosition::Samples(12000),
+            end: EndPosition::Custom(PlaybackPosition::Samples(40000)),
+        }));
+        assert_eq!(data.settings.fade_in_tween.unwrap().duration, Duration::from_millis(250));
+        drop(data);
+        assert_eq!(Arc::strong_count(&source), 2);
+    }
+
+    #[test]
+    fn oneshot_ends_at_script_range_without_loop_or_unrequested_fade() {
+        let slot = BgmPlayerSlot {
+            source_bytes: Some(wav_source()),
+            end_sample: 24000,
+            ..Default::default()
+        };
+        let data = slot.playback_data(12000, 1.0, 0).unwrap();
+        assert_eq!(data.slice, Some((0, 24000)));
+        assert!(data.settings.loop_region.is_none());
+        assert!(data.settings.fade_in_tween.is_none());
+    }
+
+    #[test]
+    fn streaming_bgm_preserves_ready_resume_pause_and_crossfade_lifecycle() {
+        let mut audio = AudioHub::new();
+        let mut bgm = BgmEngine::new(std::env::temp_dir());
+        bgm.players[0] = BgmPlayerSlot {
+            source_bytes: Some(wav_source()),
+            sample_rate_hz: 48000,
+            total_samples: 48000,
+            end_sample: 48000,
+            loop_flag: true,
+            ..Default::default()
+        };
+        bgm.current_player_id = Some(0);
+        bgm.current_name = Some("test".to_owned());
+        bgm.loop_flag = true;
+
+        bgm.ready_slot(&mut audio, 0).unwrap();
+        assert_eq!(bgm.check_state(), TNM_PLAYER_STATE_PAUSE);
+        assert_eq!(bgm.play_pos_samples(), 0);
+        bgm.resume_script(&mut audio, 20, 0).unwrap();
+        assert_eq!(bgm.check_state(), TNM_PLAYER_STATE_PLAY);
+        bgm.pause_fade(&mut audio, 20).unwrap();
+        assert_eq!(bgm.check_state(), TNM_PLAYER_STATE_FADE_OUT);
+        bgm.players[0].pending.as_mut().unwrap().at = Instant::now();
+        bgm.tick(&mut audio).unwrap();
+        assert_eq!(bgm.check_state(), TNM_PLAYER_STATE_PAUSE);
+        bgm.resume_script(&mut audio, 0, 0).unwrap();
+        bgm.handoff_current_to_retired(20);
+        assert_eq!(bgm.retired.len(), 1);
+        assert_eq!(bgm.check_state(), TNM_PLAYER_STATE_FREE);
+        bgm.retired[0].1 = Instant::now();
+        bgm.tick(&mut audio).unwrap();
+        assert!(bgm.retired.is_empty());
+        bgm.start_slot(&mut audio, 0, 0).unwrap();
+        bgm.stop().unwrap();
+        assert_eq!(bgm.check_state(), TNM_PLAYER_STATE_FREE);
+        assert!(bgm.current_name().is_none());
+    }
+
+    fn check_context_releases_streaming_decoder(restart: bool) {
+        let source = wav_source();
+        let mut ctx = crate::runtime::CommandContext::new(std::env::temp_dir());
+        ctx.bgm.players[0] = BgmPlayerSlot {
+            source_bytes: Some(Arc::clone(&source)),
+            sample_rate_hz: 48000,
+            total_samples: 48000,
+            end_sample: 48000,
+            loop_flag: true,
+            ..Default::default()
+        };
+        ctx.bgm.current_player_id = Some(0);
+        ctx.bgm.start_slot(&mut ctx.audio, 0, 0).unwrap();
+        std::thread::sleep(Duration::from_millis(20));
+        if restart {
+            ctx.reset_for_scene_restart();
+        } else {
+            drop(ctx);
+        }
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while Arc::strong_count(&source) > 1 && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert_eq!(Arc::strong_count(&source), 1, "old BGM decoder leaked after shutdown");
+    }
+
+    #[test]
+    fn restarting_context_releases_the_old_streaming_decoder() {
+        check_context_releases_streaming_decoder(true);
+    }
+
+    #[test]
+    fn dropping_context_releases_the_old_streaming_decoder() {
+        check_context_releases_streaming_decoder(false);
+    }
 }

--- a/crates/siglus_scene_vm/src/host.rs
+++ b/crates/siglus_scene_vm/src/host.rs
@@ -554,6 +554,7 @@ impl SiglusHost {
         };
         stream.jump_to_z_label(start_z.max(0) as usize)?;
         let mut ctx = CommandContext::new(project_dir);
+        ctx.install_scene_metadata(&pck)?;
         ctx.screen_w = initial_size.0;
         ctx.screen_h = initial_size.1;
         let mut vm = SceneVm::with_config(VmConfig::from_env(), stream, ctx);

--- a/crates/siglus_scene_vm/src/movie/mod.rs
+++ b/crates/siglus_scene_vm/src/movie/mod.rs
@@ -186,6 +186,8 @@ impl Drop for OmvStreamState {
     }
 }
 
+mod preview_cache;
+
 /// Minimal movie state holder.
 ///
 /// The original Siglus engine plays MOV via a native playback pipeline.
@@ -197,7 +199,7 @@ pub struct MovieManager {
     current_append_dir: String,
     current: Option<MovieInfo>,
     cache: HashMap<PathBuf, MovieAsset>,
-    preview_cache: HashMap<PathBuf, Arc<RgbaImage>>,
+    preview_cache: preview_cache::PreviewCache,
     decode_tasks: HashMap<PathBuf, Receiver<Result<MovieAsset, String>>>,
     mpeg2_audio_cache: HashMap<PathBuf, Option<MovieAudio>>,
     mpeg2_audio_tasks: HashMap<PathBuf, Mpeg2AudioTask>,
@@ -236,7 +238,7 @@ impl MovieManager {
             current_append_dir: String::new(),
             current: None,
             cache: HashMap::new(),
-            preview_cache: HashMap::new(),
+            preview_cache: preview_cache::PreviewCache::default(),
             decode_tasks: HashMap::new(),
             mpeg2_audio_cache: HashMap::new(),
             mpeg2_audio_tasks: HashMap::new(),
@@ -246,6 +248,12 @@ impl MovieManager {
             next_playback_id: 1,
             path_cache: HashMap::new(),
         }
+    }
+
+    pub fn reset_for_scene_restart(&mut self) {
+        let preview_cache = std::mem::take(&mut self.preview_cache);
+        *self = Self::new(self.project_dir.clone());
+        self.preview_cache = preview_cache;
     }
 
     pub fn current(&self) -> Option<&MovieInfo> {
@@ -889,7 +897,7 @@ impl MovieManager {
 
     fn ensure_preview_frame_for_path(&mut self, path: PathBuf) -> Result<Arc<RgbaImage>> {
         if let Some(frame) = self.preview_cache.get(&path) {
-            return Ok(frame.clone());
+            return Ok(frame);
         }
         let ext = path
             .extension()

--- a/crates/siglus_scene_vm/src/movie/preview_cache.rs
+++ b/crates/siglus_scene_vm/src/movie/preview_cache.rs
@@ -1,0 +1,109 @@
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::assets::RgbaImage;
+
+// Preview pixels are immutable file resources, unlike movie playbacks. Keep
+// a small LRU across scene restarts without retaining streams or ImageIds.
+const MAX_BYTES: usize = 32 * 1024 * 1024;
+const MAX_ENTRIES: usize = 8;
+
+#[derive(Debug, Default)]
+pub(super) struct PreviewCache {
+    entries: VecDeque<(PathBuf, Arc<RgbaImage>)>,
+    bytes: usize,
+}
+
+impl PreviewCache {
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn get(&mut self, path: &Path) -> Option<Arc<RgbaImage>> {
+        let index = self.entries.iter().position(|(key, _)| key == path)?;
+        let entry = self.entries.remove(index)?;
+        let image = Arc::clone(&entry.1);
+        self.entries.push_back(entry);
+        Some(image)
+    }
+
+    pub fn insert(&mut self, path: PathBuf, image: Arc<RgbaImage>) {
+        self.insert_with_limits(path, image, MAX_BYTES, MAX_ENTRIES);
+    }
+
+    fn insert_with_limits(
+        &mut self,
+        path: PathBuf,
+        image: Arc<RgbaImage>,
+        max_bytes: usize,
+        max_entries: usize,
+    ) {
+        if let Some(index) = self.entries.iter().position(|(key, _)| key == &path) {
+            let (_, old) = self.entries.remove(index).unwrap();
+            self.bytes -= old.rgba.len();
+        }
+        let size = image.rgba.len();
+        if size > max_bytes || max_entries == 0 {
+            return;
+        }
+        while self.bytes > max_bytes - size || self.entries.len() >= max_entries {
+            let (_, old) = self.entries.pop_front().unwrap();
+            self.bytes -= old.rgba.len();
+        }
+        self.bytes += size;
+        self.entries.push_back((path, image));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn image(value: u8) -> Arc<RgbaImage> {
+        Arc::new(RgbaImage {
+            width: 1,
+            height: 1,
+            center_x: 0,
+            center_y: 0,
+            rgba: vec![value; 4],
+        })
+    }
+
+    #[test]
+    fn preview_cache_is_lru_bounded_and_replacement_accounts_bytes() {
+        let mut cache = PreviewCache::default();
+        let a = image(1);
+        cache.insert_with_limits("a".into(), Arc::clone(&a), 8, 2);
+        cache.insert_with_limits("b".into(), image(2), 8, 2);
+        assert!(Arc::ptr_eq(&cache.get(Path::new("a")).unwrap(), &a));
+        cache.insert_with_limits("c".into(), image(3), 8, 2);
+        assert!(cache.get(Path::new("b")).is_none());
+        assert_eq!(cache.bytes, 8);
+        cache.insert_with_limits("a".into(), image(4), 8, 2);
+        assert_eq!(cache.bytes, 8);
+        assert_eq!(cache.get(Path::new("a")).unwrap().rgba, vec![4; 4]);
+        cache.insert_with_limits("oversized".into(), image(5), 3, 2);
+        assert!(cache.get(Path::new("oversized")).is_none());
+    }
+
+    #[test]
+    fn scene_restart_keeps_preview_pixels_but_resets_playback_state() {
+        let mut manager = super::super::MovieManager::new("preview-cache-test".into());
+        let frame = image(7);
+        let path = PathBuf::from("missing-but-cached.omv");
+        manager
+            .preview_cache
+            .insert(path.clone(), Arc::clone(&frame));
+        manager.current_append_dir = "append".into();
+        manager.next_playback_id = 42;
+        manager.reset_for_scene_restart();
+        assert!(manager.current_append_dir.is_empty());
+        assert_eq!(manager.next_playback_id, 1);
+        assert!(manager.playbacks.is_empty());
+        assert!(Arc::ptr_eq(
+            &manager.ensure_preview_frame_for_path(path).unwrap(),
+            &frame
+        ));
+    }
+}

--- a/crates/siglus_scene_vm/src/render/mipmap.rs
+++ b/crates/siglus_scene_vm/src/render/mipmap.rs
@@ -1,0 +1,254 @@
+//! Generate texture mip levels on the renderer's GPU, not in the script tick.
+
+#[derive(Debug)]
+pub(super) struct MipmapGenerator {
+    layout: wgpu::BindGroupLayout,
+    pipeline: wgpu::RenderPipeline,
+    pending: std::cell::RefCell<Option<wgpu::CommandEncoder>>,
+}
+
+impl MipmapGenerator {
+    pub fn new(device: &wgpu::Device) -> Self {
+        let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("siglus-mipmap-layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                },
+                count: None,
+            }],
+        });
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("siglus-mipmap-shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("mipmap.wgsl").into()),
+        });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("siglus-mipmap-pipeline-layout"),
+            bind_group_layouts: &[&layout],
+            push_constant_ranges: &[],
+        });
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("siglus-mipmap-pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_main",
+                compilation_options: Default::default(),
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_main",
+                compilation_options: Default::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: wgpu::TextureFormat::Rgba8Unorm,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: Default::default(),
+            depth_stencil: None,
+            multisample: Default::default(),
+            multiview: None,
+        });
+        Self {
+            layout,
+            pipeline,
+            pending: Default::default(),
+        }
+    }
+
+    pub fn generate(&self, device: &wgpu::Device, texture: &wgpu::Texture) {
+        let count = texture.mip_level_count();
+        if count <= 1 {
+            return;
+        }
+        let views: Vec<_> = (0..count)
+            .map(|level| {
+                texture.create_view(&wgpu::TextureViewDescriptor {
+                    label: Some("siglus-mipmap-level"),
+                    base_mip_level: level,
+                    mip_level_count: Some(1),
+                    ..Default::default()
+                })
+            })
+            .collect();
+        let mut pending = self.pending.borrow_mut();
+        let encoder = pending.get_or_insert_with(|| {
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("siglus-mipmap-encoder"),
+            })
+        });
+        for level in 1..count as usize {
+            let source = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("siglus-mipmap-source"),
+                layout: &self.layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&views[level - 1]),
+                }],
+            });
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("siglus-mipmap-pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &views[level],
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            pass.set_pipeline(&self.pipeline);
+            pass.set_bind_group(0, &source, &[]);
+            pass.draw(0..3, 0..1);
+        }
+    }
+
+    /// Submit one batch before the consuming render/capture commands. Submitting
+    /// each glyph texture separately costs more than filtering its few pixels.
+    pub fn finish(&self) -> Option<wgpu::CommandBuffer> {
+        self.pending
+            .borrow_mut()
+            .take()
+            .map(wgpu::CommandEncoder::finish)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_level(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        texture: &wgpu::Texture,
+        level: u32,
+    ) -> Vec<u8> {
+        let width = (texture.width() >> level).max(1);
+        let height = (texture.height() >> level).max(1);
+        let stride = (width * 4).div_ceil(256) * 256;
+        let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("mipmap-test-readback"),
+            size: u64::from(stride) * u64::from(height),
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+        let mut encoder = device.create_command_encoder(&Default::default());
+        encoder.copy_texture_to_buffer(
+            wgpu::ImageCopyTexture {
+                texture,
+                mip_level: level,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::ImageCopyBuffer {
+                buffer: &buffer,
+                layout: wgpu::ImageDataLayout {
+                    offset: 0,
+                    bytes_per_row: Some(stride),
+                    rows_per_image: Some(height),
+                },
+            },
+            wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit(Some(encoder.finish()));
+        let (tx, rx) = std::sync::mpsc::channel();
+        buffer
+            .slice(..)
+            .map_async(wgpu::MapMode::Read, move |result| tx.send(result).unwrap());
+        device.poll(wgpu::Maintain::Wait);
+        rx.recv().unwrap().unwrap();
+        let mapped = buffer.slice(..).get_mapped_range();
+        let result = mapped
+            .chunks_exact(stride as usize)
+            .flat_map(|row| row[..width as usize * 4].iter().copied())
+            .collect();
+        drop(mapped);
+        buffer.unmap();
+        result
+    }
+
+    #[test]
+    fn gpu_mips_match_integer_reference_including_odd_sizes_alpha_and_updates() {
+        let instance = wgpu::Instance::default();
+        let Some(adapter) = pollster::block_on(instance.request_adapter(&Default::default()))
+        else {
+            eprintln!("GPU mipmap comparison skipped: no graphics adapter");
+            return;
+        };
+        eprintln!("GPU mipmap comparison adapter: {}", adapter.get_info().name);
+        let (device, queue) = pollster::block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::downlevel_defaults(),
+                label: Some("mipmap-test-device"),
+            },
+            None,
+        ))
+        .unwrap();
+        let generator = MipmapGenerator::new(&device);
+        let mut textures = Vec::new();
+        for (width, height) in [(1, 1), (1, 17), (19, 1), (3, 5), (16, 8), (129, 65)] {
+            let img = crate::assets::RgbaImage {
+                width,
+                height,
+                center_x: 0,
+                center_y: 0,
+                rgba: (0..width * height * 4)
+                    .map(|i| ((i * 73 + i / 7) % 256) as u8)
+                    .collect(),
+            };
+            let texture = super::super::create_gpu_texture(
+                &device,
+                &queue,
+                &generator,
+                "mipmap-test",
+                &img,
+                0,
+            )
+            .unwrap();
+            textures.push((img, texture));
+        }
+        for revision in 0..2 {
+            if revision == 1 {
+                for (img, texture) in &mut textures {
+                    for value in &mut img.rgba {
+                        *value = 255 - *value;
+                    }
+                    super::super::upload_texture_pixels(&queue, &texture._tex, img);
+                    generator.generate(&device, &texture._tex);
+                }
+            }
+            // Multiple textures are prepared and updated before one consuming
+            // submission, just like prepare_draws. Finishing drains the batch.
+            queue.submit(Some(generator.finish().expect("batched mipmaps")));
+            assert!(generator.finish().is_none());
+            for (img, texture) in &textures {
+                let (width, height) = (img.width, img.height);
+                for (level, expected) in
+                    super::super::build_rgba8_mip_chain(width, height, &img.rgba)
+                        .iter()
+                        .enumerate()
+                {
+                    assert_eq!(
+                        read_level(&device, &queue, &texture._tex, level as u32),
+                        expected.rgba,
+                        "{width}x{height} mip={level} revision={revision}"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/siglus_scene_vm/src/render/mipmap.wgsl
+++ b/crates/siglus_scene_vm/src/render/mipmap.wgsl
@@ -1,0 +1,21 @@
+@group(0) @binding(0) var source: texture_2d<f32>;
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex: u32) -> @builtin(position) vec4<f32> {
+    var positions = array<vec2<f32>, 3>(vec2<f32>(-1.0, -1.0), vec2<f32>(3.0, -1.0), vec2<f32>(-1.0, 3.0));
+    return vec4<f32>(positions[vertex], 0.0, 1.0);
+}
+
+@fragment
+fn fs_main(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
+    let upper = vec2<i32>(textureDimensions(source)) - vec2<i32>(1);
+    let p0 = vec2<i32>(position.xy) * 2;
+    let p1 = min(p0 + vec2<i32>(1), upper);
+    // Preserve the CPU path's stored-byte box filter and round-half-up,
+    // including clamping along a one-pixel axis. Do not filter in sRGB.
+    let a = vec4<u32>(round(textureLoad(source, p0, 0) * 255.0));
+    let b = vec4<u32>(round(textureLoad(source, vec2<i32>(p1.x, p0.y), 0) * 255.0));
+    let c = vec4<u32>(round(textureLoad(source, vec2<i32>(p0.x, p1.y), 0) * 255.0));
+    let d = vec4<u32>(round(textureLoad(source, p1, 0) * 255.0));
+    return vec4<f32>((a + b + c + d + vec4<u32>(2)) / vec4<u32>(4)) / 255.0;
+}

--- a/crates/siglus_scene_vm/src/render/mod.rs
+++ b/crates/siglus_scene_vm/src/render/mod.rs
@@ -22,6 +22,7 @@ use crate::runtime::FrameCaptureBackend;
 use crate::render_math::sprite_quad_points;
 
 mod emote;
+mod mipmap;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable)]
@@ -672,6 +673,7 @@ pub struct Renderer {
     vertex_sprite2d_capacity: usize,
 
     textures: HashMap<ImageId, GpuTexture>,
+    mipmap_generator: mipmap::MipmapGenerator,
     external_textures: HashMap<PathBuf, GpuTexture>,
     mesh_assets: HashMap<String, MeshAsset>,
     default_aux: GpuTexture,
@@ -2172,7 +2174,8 @@ impl Renderer {
         #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
         let vertex_sprite2d_capacity = vertex_capacity;
 
-        let default_aux = create_solid_texture(&device, &queue, [255, 255, 255, 255])?;
+        let mipmap_generator = mipmap::MipmapGenerator::new(&device);
+        let default_aux = create_solid_texture(&device, &queue, &mipmap_generator, [255, 255, 255, 255])?;
         let fog_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             label: Some("siglus-cfx-fog-sampler"),
             address_mode_u: wgpu::AddressMode::ClampToEdge,
@@ -2302,6 +2305,7 @@ impl Renderer {
             external_textures: HashMap::new(),
             mesh_assets: HashMap::new(),
             default_aux,
+            mipmap_generator,
             fog_sampler,
             mesh_sampler,
             normal_sampler,
@@ -2490,7 +2494,7 @@ impl Renderer {
                 final_target,
                 blit_range,
             )?;
-            self.queue.submit(Some(encoder.finish()));
+            self.submit(encoder);
         } else {
             self.render_ordinary_frame_to_surface(images, &frame_plan.sprites, &view)?;
         }
@@ -2554,7 +2558,7 @@ impl Renderer {
             None,
             None,
         )?;
-        self.queue.submit(Some(encoder.finish()));
+        self.submit(encoder);
         Ok(())
     }
 
@@ -3651,7 +3655,7 @@ impl Renderer {
                 )?;
             }
         }
-        self.queue.submit(Some(encoder.finish()));
+        self.submit(encoder);
         Ok(current)
     }
 
@@ -3684,7 +3688,7 @@ impl Renderer {
                 depth_or_array_layers: 1,
             },
         );
-        self.queue.submit(Some(encoder.finish()));
+        self.submit(encoder);
     }
 
 
@@ -3729,6 +3733,7 @@ impl Renderer {
         let texture = create_gpu_texture(
             &self.device,
             &self.queue,
+            &self.mipmap_generator,
             "siglus-generated-wipe-mask",
             &image,
             wipe.random_seed as u64,
@@ -3842,7 +3847,7 @@ impl Renderer {
             pass.set_bind_group(0, &bind_group, &[]);
             pass.draw(0..3, 0..1);
         }
-        self.queue.submit(Some(encoder.finish()));
+        self.submit(encoder);
         Ok(target)
     }
 
@@ -3954,7 +3959,7 @@ impl Renderer {
                 pass.draw(0..draw.vertices.len() as u32, 0..1);
             }
         }
-        self.queue.submit(Some(encoder.finish()));
+        self.submit(encoder);
         Ok(())
     }
 
@@ -4342,7 +4347,7 @@ impl Renderer {
                 depth_or_array_layers: 1,
             },
         );
-        self.queue.submit(Some(encoder.finish()));
+        self.submit(encoder);
 
         let buffer_slice = output_buffer.slice(..);
         let (tx, rx) = std::sync::mpsc::channel();
@@ -4401,6 +4406,7 @@ impl Renderer {
         let tex = create_gpu_texture(
             &self.device,
             &self.queue,
+            &self.mipmap_generator,
             &format!("siglus-external-texture-{}", self.external_textures.len()),
             &img,
             0,
@@ -5206,6 +5212,7 @@ impl Renderer {
                     tex = create_gpu_texture(
                         &self.device,
                         &self.queue,
+                        &self.mipmap_generator,
                         &format!("siglus-texture-{}", id.index()),
                         img,
                         version,
@@ -5218,6 +5225,7 @@ impl Renderer {
             let tex = create_gpu_texture(
                 &self.device,
                 &self.queue,
+                &self.mipmap_generator,
                 &format!("siglus-texture-{}", id.index()),
                 img,
                 version,
@@ -5231,26 +5239,15 @@ impl Renderer {
         if tex.width != img.width || tex.height != img.height {
             return Ok(());
         }
-        self.queue.write_texture(
-            wgpu::ImageCopyTexture {
-                texture: &tex._tex,
-                mip_level: 0,
-                origin: wgpu::Origin3d::ZERO,
-                aspect: wgpu::TextureAspect::All,
-            },
-            &img.rgba,
-            wgpu::ImageDataLayout {
-                offset: 0,
-                bytes_per_row: Some(4 * img.width),
-                rows_per_image: Some(img.height),
-            },
-            wgpu::Extent3d {
-                width: img.width,
-                height: img.height,
-                depth_or_array_layers: 1,
-            },
-        );
+        upload_texture_pixels(&self.queue, &tex._tex, img);
+        self.mipmap_generator.generate(&self.device, &tex._tex);
         Ok(())
+    }
+
+    fn submit(&self, encoder: wgpu::CommandEncoder) {
+        // All mip levels must be populated before any draw or capture samples
+        // newly uploaded pixels, including intermediate wipe/backdrop passes.
+        self.queue.submit(self.mipmap_generator.finish().into_iter().chain(Some(encoder.finish())));
     }
 }
 impl FrameCaptureBackend for Renderer {
@@ -5293,6 +5290,7 @@ impl FrameCaptureBackend for Renderer {
 fn create_solid_texture(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
+    mipmap_generator: &mipmap::MipmapGenerator,
     rgba: [u8; 4],
 ) -> Result<GpuTexture> {
     let img = crate::assets::RgbaImage {
@@ -5302,10 +5300,11 @@ fn create_solid_texture(
         center_y: 0,
         rgba: rgba.to_vec(),
     };
-    create_gpu_texture(device, queue, "siglus-default-aux", &img, 0)
+    create_gpu_texture(device, queue, mipmap_generator, "siglus-default-aux", &img, 0)
 }
 
 
+#[cfg(test)]
 #[derive(Debug)]
 struct Rgba8MipLevel {
     width: u32,
@@ -5316,6 +5315,7 @@ struct Rgba8MipLevel {
 /// Build the same kind of full mip chain requested by the original
 /// D3DUSAGE_AUTOGENMIPMAP textures.  Values are averaged in the stored 8-bit
 /// color space rather than converted through sRGB, matching the D3D9 setup.
+#[cfg(test)]
 fn build_rgba8_mip_chain(width: u32, height: u32, rgba: &[u8]) -> Vec<Rgba8MipLevel> {
     if width == 0 || height == 0 || rgba.len() < width as usize * height as usize * 4 {
         return Vec::new();
@@ -5369,12 +5369,16 @@ fn build_rgba8_mip_chain(width: u32, height: u32, rgba: &[u8]) -> Vec<Rgba8MipLe
 fn create_gpu_texture(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
+    mipmap_generator: &mipmap::MipmapGenerator,
     label: &str,
     img: &crate::assets::RgbaImage,
     version: u64,
 ) -> Result<GpuTexture> {
-    let mip_chain = build_rgba8_mip_chain(img.width, img.height, &img.rgba);
-    let mip_level_count = mip_chain.len().max(1) as u32;
+    anyhow::ensure!(img.width > 0 && img.height > 0, "empty texture dimensions");
+    let pixel_bytes = (img.width as usize).checked_mul(img.height as usize)
+        .and_then(|n| n.checked_mul(4)).context("texture size overflow")?;
+    anyhow::ensure!(img.rgba.len() >= pixel_bytes, "truncated texture pixels");
+    let mip_level_count = u32::BITS - img.width.max(img.height).leading_zeros();
     let tex = device.create_texture(&wgpu::TextureDescriptor {
         label: Some(label),
         size: wgpu::Extent3d {
@@ -5388,31 +5392,13 @@ fn create_gpu_texture(
         format: wgpu::TextureFormat::Rgba8Unorm,
         usage: wgpu::TextureUsages::TEXTURE_BINDING
             | wgpu::TextureUsages::COPY_DST
-            | wgpu::TextureUsages::COPY_SRC,
+            | wgpu::TextureUsages::COPY_SRC
+            | wgpu::TextureUsages::RENDER_ATTACHMENT,
         view_formats: &[],
     });
 
-    for (mip_level, mip) in mip_chain.iter().enumerate() {
-        queue.write_texture(
-            wgpu::ImageCopyTexture {
-                texture: &tex,
-                mip_level: mip_level as u32,
-                origin: wgpu::Origin3d::ZERO,
-                aspect: wgpu::TextureAspect::All,
-            },
-            &mip.rgba,
-            wgpu::ImageDataLayout {
-                offset: 0,
-                bytes_per_row: Some(4 * mip.width),
-                rows_per_image: Some(mip.height),
-            },
-            wgpu::Extent3d {
-                width: mip.width,
-                height: mip.height,
-                depth_or_array_layers: 1,
-            },
-        );
-    }
+    upload_texture_pixels(queue, &tex, img);
+    mipmap_generator.generate(device, &tex);
 
     let view = tex.create_view(&wgpu::TextureViewDescriptor::default());
     let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
@@ -5434,6 +5420,19 @@ fn create_gpu_texture(
         height: img.height,
         version,
     })
+}
+
+fn upload_texture_pixels(queue: &wgpu::Queue, texture: &wgpu::Texture, img: &crate::assets::RgbaImage) {
+    queue.write_texture(
+        wgpu::ImageCopyTexture {
+            texture, mip_level: 0, origin: wgpu::Origin3d::ZERO, aspect: wgpu::TextureAspect::All,
+        },
+        &img.rgba,
+        wgpu::ImageDataLayout {
+            offset: 0, bytes_per_row: Some(4 * img.width), rows_per_image: Some(img.height),
+        },
+        wgpu::Extent3d { width: img.width, height: img.height, depth_or_array_layers: 1 },
+    );
 }
 
 fn create_render_target_texture(

--- a/crates/siglus_scene_vm/src/runtime/forms/syscom.rs
+++ b/crates/siglus_scene_vm/src/runtime/forms/syscom.rs
@@ -10,8 +10,6 @@ use std::path::{Path, PathBuf};
 
 use crate::assets::RgbaImage;
 use crate::original_save::{self, SaveKind};
-use crate::scene_stream::ScnHeader;
-use siglus_assets::scene_pck::{ScenePck, ScenePckDecodeOptions};
 
 use super::prop_access;
 
@@ -1650,68 +1648,18 @@ fn load_config_save(ctx: &mut CommandContext) -> Result<()> {
 }
 
 
-fn load_scene_pack_for_read_flags(ctx: &CommandContext) -> Result<ScenePck> {
-    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-    {
-        let scene_pck_path = ctx.project_dir.join("Scene.pck");
-        let bytes = crate::resource::read_file_bytes(&scene_pck_path)?;
-        let exe = ["key.toml", "Key.toml"]
-            .iter()
-            .find_map(|name| {
-                let path = ctx.project_dir.join(name);
-                if !crate::resource::wasm_path_is_file(&path) {
-                    return None;
-                }
-                let text = crate::resource::read_file_to_string(&path).ok()?;
-                siglus_assets::key_toml::parse_key_toml(&text)
-                    .ok()
-                    .and_then(|cfg| cfg.exe_key16)
-                    .map(|key| key.to_vec())
-            });
-        let opt = ScenePckDecodeOptions {
-            exe_angou_element: exe,
-            easy_angou_code: Some(siglus_assets::keys::SCENE_KEY.to_vec()),
-        };
-        return ScenePck::load_and_rebuild_from_bytes(bytes, &opt);
-    }
-
-    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-    {
-        let scene_pck_path = crate::resource::find_scene_pck_path(&ctx.project_dir)?;
-        let opt = ScenePckDecodeOptions::from_project_dir(&ctx.project_dir)?;
-        ScenePck::load_and_rebuild(&scene_pck_path, &opt)
-    }
-}
-
-fn scene_read_flag_shape(pck: &ScenePck, scene_no: usize) -> Result<(String, usize)> {
-    let scene_name = pck
-        .find_scene_name(scene_no)
-        .map(ToOwned::to_owned)
-        .unwrap_or_else(|| scene_no.to_string());
-    let chunk = pck.scn_data_slice(scene_no)?;
-    let flag_count = if chunk.is_empty() {
-        0
-    } else {
-        ScnHeader::read(chunk)?.read_flag_cnt.max(0) as usize
-    };
-    Ok((scene_name, flag_count))
-}
-
 fn write_read_flags(ctx: &CommandContext) -> Result<()> {
-    let pck = load_scene_pack_for_read_flags(ctx)?;
-    let scene_count = pck.header.scn_data_cnt.max(0) as usize;
-    let mut rows = Vec::with_capacity(scene_count);
-    for scene_no in 0..scene_count {
-        let (scene_name, flag_count) = scene_read_flag_shape(&pck, scene_no)?;
+    let metadata = ctx.scene_metadata()?;
+    let mut rows = Vec::with_capacity(metadata.rows.len());
+    for (scene_no, (scene_name, flag_count)) in metadata.rows.iter().enumerate() {
         let mut flags = ctx
             .globals
             .read_flags
             .get(&(scene_no as i64))
             .cloned()
             .unwrap_or_default();
-        flags.resize(flag_count, 0);
-        flags.truncate(flag_count);
-        rows.push((scene_name, flags));
+        flags.resize(*flag_count, 0);
+        rows.push((scene_name.clone(), flags));
     }
     original_save::write_read_save_file(&ctx.project_dir, &rows)
 }
@@ -1721,13 +1669,11 @@ fn load_read_flags(ctx: &mut CommandContext) -> Result<()> {
     if crate::resource::resolve_windows_case_insensitive_file(&read_path)?.is_none() {
         return Ok(());
     }
-    let pck = load_scene_pack_for_read_flags(ctx)?;
-    let scene_count = pck.header.scn_data_cnt.max(0) as usize;
+    let metadata = ctx.scene_metadata()?;
     ctx.globals.read_flags.clear();
-    for scene_no in 0..scene_count {
-        let (_, flag_count) = scene_read_flag_shape(&pck, scene_no)?;
+    for (scene_no, (_, flag_count)) in metadata.rows.iter().enumerate() {
         ctx.globals
-            .ensure_read_flag_count(scene_no as i64, flag_count);
+            .ensure_read_flag_count(scene_no as i64, *flag_count);
     }
 
     let rows = match original_save::read_read_save_file(&ctx.project_dir) {
@@ -1735,14 +1681,16 @@ fn load_read_flags(ctx: &mut CommandContext) -> Result<()> {
         Err(_) => return Ok(()),
     };
     for (scene_name, saved_flags) in rows {
-        let Some(scene_no) = pck.find_scene_no(&scene_name) else {
+        let Some(scene_no) = metadata.find_scene_no(&scene_name) else {
             continue;
         };
-        let (_, real_flag_count) = scene_read_flag_shape(&pck, scene_no)?;
+        let Some((_, real_flag_count)) = metadata.rows.get(scene_no) else {
+            continue;
+        };
         // Original C++ applies a row only when its saved count exactly matches
         // the current scene lexer.  This prevents shifted flags after script
         // recompilation from marking unrelated lines as read.
-        if saved_flags.len() == real_flag_count {
+        if saved_flags.len() == *real_flag_count {
             ctx.globals
                 .read_flags
                 .insert(scene_no as i64, saved_flags);
@@ -1893,7 +1841,9 @@ pub fn load_global_save(ctx: &mut CommandContext) -> Result<()> {
         let chrkoe_cnt = rd.i32()?;
         for _ in 0..chrkoe_cnt.max(0) {
             let _name = rd.string()?;
-            let _look_flag = rd.i32()?;
+            // The original stream writes this flag as a one-byte bool. Reading
+            // an i32 consumes the start of the next UTF-16 string's length.
+            let _look_flag = rd.bool()?;
         }
 
         ctx.globals.syscom.total_play_time = total_play_time;
@@ -5928,6 +5878,42 @@ mod global_save_init_tests {
     }
 
     #[test]
+    fn read_flags_reuse_resident_scene_metadata_and_preserve_shape_checks() {
+        let project_dir = test_project_dir();
+        fs::create_dir_all(&project_dir).unwrap();
+        let mut ctx = CommandContext::new(project_dir.clone());
+        let metadata = crate::runtime::scene_metadata::SceneMetadata::from_rows(vec![
+            ("Story".to_owned(), 3),
+            ("Menu".to_owned(), 2),
+            ("Empty".to_owned(), 0),
+        ]);
+        ctx.scene_metadata.set(std::sync::Arc::new(metadata)).unwrap();
+        ctx.globals.read_flags.insert(0, vec![1, 0, 1, 1]);
+        ctx.globals.read_flags.insert(1, vec![1]);
+
+        // No Scene.pck exists: repeated saves must not read/decrypt it.
+        write_read_flags(&ctx).unwrap();
+        write_read_flags(&ctx).unwrap();
+        let rows = original_save::read_read_save_file(&project_dir).unwrap();
+        assert_eq!(rows, vec![
+            ("Story".to_owned(), vec![1, 0, 1]),
+            ("Menu".to_owned(), vec![1, 0]),
+            ("Empty".to_owned(), vec![]),
+        ]);
+        assert_eq!(ctx.lookup_scene_no("STORY").unwrap(), 0);
+        original_save::write_read_save_file(&project_dir, &[
+            ("story".to_owned(), vec![0, 1, 0]),
+            ("Menu".to_owned(), vec![1]), // stale script layout: discard
+            ("Removed".to_owned(), vec![1]),
+        ]).unwrap();
+        load_read_flags(&mut ctx).unwrap();
+        assert_eq!(ctx.globals.read_flags[&0], vec![0, 1, 0]);
+        assert_eq!(ctx.globals.read_flags[&1], vec![0, 0]);
+        assert!(ctx.globals.read_flags[&2].is_empty());
+        fs::remove_dir_all(project_dir).unwrap();
+    }
+
+    #[test]
     fn missing_global_save_keeps_zero_initialized_flags() {
         let project_dir = test_project_dir();
         fs::create_dir_all(&project_dir).expect("test project dir");
@@ -5955,6 +5941,37 @@ mod global_save_init_tests {
 
         assert!(load_global_save(&mut ctx).is_err());
 
+        let _ = fs::remove_dir_all(project_dir);
+    }
+
+    #[test]
+    fn original_global_save_reads_byte_sized_character_voice_flags() {
+        let project_dir = test_project_dir();
+        fs::create_dir_all(&project_dir).expect("test project dir");
+        let mut stream = original_save::OriginalStreamWriter::new();
+        stream.push_i64(1234);
+        stream.push_fixed_i32_list(&[42], 1);
+        stream.push_fixed_i32_list(&[7], 1);
+        stream.push_fixed_str_list(&["global".to_string()], 1);
+        stream.push_fixed_str_list(&[], 0);
+        stream.push_i32(0);
+        stream.push_fixed_i32_list(&[1], 1);
+        stream.push_fixed_i32_list(&[1], 1);
+        stream.push_i32(3);
+        for (name, seen) in [("", true), ("テスト", false), ("角色", true)] {
+            stream.push_str(name);
+            stream.push_bool(seen);
+        }
+        original_save::write_global_save_file(&project_dir, &stream.into_inner())
+            .expect("synthetic original global save");
+        let mut ctx = CommandContext::new(project_dir.clone());
+
+        load_global_save(&mut ctx).expect("original one-byte voice flags");
+
+        assert_eq!(ctx.globals.syscom.total_play_time, 1234);
+        assert_eq!(ctx.globals.int_lists[&(codes::ELM_GLOBAL_G as u32)][0], 42);
+        assert_eq!(ctx.globals.int_lists[&(codes::ELM_GLOBAL_Z as u32)][0], 7);
+        assert_eq!(ctx.globals.str_lists[&(codes::ELM_GLOBAL_M as u32)][0], "global");
         let _ = fs::remove_dir_all(project_dir);
     }
 }

--- a/crates/siglus_scene_vm/src/runtime/mod.rs
+++ b/crates/siglus_scene_vm/src/runtime/mod.rs
@@ -16,6 +16,7 @@ pub mod game_title;
 pub mod globals;
 pub mod int_event;
 pub mod string_semantics;
+mod scene_metadata;
 pub mod net;
 pub mod native_ui;
 pub mod tables;
@@ -35,6 +36,7 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
+use scene_metadata::SceneMetadata;
 
 use crate::assets::RgbaImage;
 use crate::audio::{AudioHub, BgmEngine, KoeEngine, PcmEngine, SeEngine};
@@ -352,9 +354,10 @@ pub struct CommandContext {
     /// 1x1 white sprite used for screen-space overlays (filters, etc.).
     pub solid_white: ImageId,
 
-    pub audio: AudioHub,
-
+    // Drop players before their mixer: streaming stop commands must reach the
+    // final render batch when this context is closed.
     pub bgm: BgmEngine,
+    pub audio: AudioHub,
     pub koe: KoeEngine,
     pub pcm: PcmEngine,
     pub se: SeEngine,
@@ -397,6 +400,10 @@ pub struct CommandContext {
 
     /// Gameexe-driven asset tables (CGTABLE / DATABASE / THUMBTABLE).
     pub tables: tables::AssetTables,
+
+    // Runtime-only metadata, not part of any save or scene restart. The loaded
+    // game's scene layout does not change when returning to its title screen.
+    scene_metadata: OnceLock<Arc<SceneMetadata>>,
 
     /// Value stack used by form handlers to return results.
     pub stack: Vec<Value>,
@@ -1166,6 +1173,7 @@ impl CommandContext {
             emote_key,
             solid_white,
             tables,
+            scene_metadata: OnceLock::new(),
             stack: Vec::new(),
             unknown,
             ids,
@@ -1662,10 +1670,20 @@ impl CommandContext {
         }
     }
 
-    pub fn lookup_scene_no(&self, scene_name: &str) -> Result<i64> {
-        if scene_name.is_empty() {
-            anyhow::bail!("empty scene name")
+    pub(crate) fn install_scene_metadata(&self, pck: &ScenePck) -> Result<()> {
+        if self.scene_metadata.get().is_none() {
+            let metadata = Arc::new(SceneMetadata::from_pack(pck)?);
+            let _ = self.scene_metadata.set(metadata);
         }
+        Ok(())
+    }
+
+    pub(crate) fn scene_metadata(&self) -> Result<Arc<SceneMetadata>> {
+        if let Some(metadata) = self.scene_metadata.get() {
+            return Ok(Arc::clone(metadata));
+        }
+        // Standalone command contexts may not have a VM yet. Load once as a
+        // fallback; normal host initialization installs its existing pack.
         #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
         let pck = {
             let scene_pck_path = self.project_dir.join("Scene.pck");
@@ -1695,19 +1713,27 @@ impl CommandContext {
             let opt = ScenePckDecodeOptions::from_project_dir(&self.project_dir)?;
             ScenePck::load_and_rebuild(&scene_pck_path, &opt)?
         };
-        let scene_no = pck
+        self.install_scene_metadata(&pck)?;
+        Ok(Arc::clone(self.scene_metadata.get().expect("scene metadata initialized")))
+    }
+
+    pub fn lookup_scene_no(&self, scene_name: &str) -> Result<i64> {
+        if scene_name.is_empty() {
+            anyhow::bail!("empty scene name")
+        }
+        let scene_no = self.scene_metadata()?
             .find_scene_no(scene_name)
             .ok_or_else(|| anyhow::anyhow!("scene not found: {}", scene_name))?;
         Ok(scene_no as i64)
     }
 
     pub fn reset_for_scene_restart(&mut self) {
-        self.audio = AudioHub::new();
         self.bgm = BgmEngine::new(self.project_dir.clone());
+        self.audio = AudioHub::new();
         self.koe = KoeEngine::new(self.project_dir.clone());
         self.pcm = PcmEngine::new(self.project_dir.clone());
         self.se = SeEngine::new(self.project_dir.clone());
-        self.movie = MovieManager::new(self.project_dir.clone());
+        self.movie.reset_for_scene_restart();
         self.images = ImageManager::new(self.project_dir.clone());
         self.mouse_cursor_cache.clear();
         self.solid_white = self.images.solid_rgba((255, 255, 255, 255));

--- a/crates/siglus_scene_vm/src/runtime/scene_metadata.rs
+++ b/crates/siglus_scene_vm/src/runtime/scene_metadata.rs
@@ -1,0 +1,58 @@
+//! Immutable scene information shared by the VM and global-save operations.
+
+use anyhow::Result;
+use siglus_assets::scene_pck::ScenePck;
+use std::collections::HashMap;
+
+use crate::scene_stream::ScnHeader;
+
+#[derive(Debug)]
+pub(crate) struct SceneMetadata {
+    pub rows: Vec<(String, usize)>,
+    names: HashMap<String, usize>,
+}
+
+impl SceneMetadata {
+    pub fn from_pack(pck: &ScenePck) -> Result<Self> {
+        let count = pck.header.scn_data_cnt.max(0) as usize;
+        let mut rows = Vec::with_capacity(count);
+        for scene_no in 0..count {
+            let name = pck
+                .find_scene_name(scene_no)
+                .map(ToOwned::to_owned)
+                .unwrap_or_else(|| scene_no.to_string());
+            let chunk = pck.scn_data_slice(scene_no)?;
+            let flags = if chunk.is_empty() {
+                0
+            } else {
+                ScnHeader::read(chunk)?.read_flag_cnt.max(0) as usize
+            };
+            rows.push((name, flags));
+        }
+        let mut metadata = Self::from_rows(rows);
+        metadata.names = pck.scn_name_map.clone();
+        Ok(metadata)
+    }
+
+    pub fn from_rows(rows: Vec<(String, usize)>) -> Self {
+        let names = rows
+            .iter()
+            .enumerate()
+            .map(|(no, (name, _))| (name.clone(), no))
+            .collect();
+        Self { rows, names }
+    }
+
+    pub fn find_scene_no(&self, name: &str) -> Option<usize> {
+        if let Ok(no) = name.parse::<usize>() {
+            return Some(no);
+        }
+        self.names.get(name).copied().or_else(|| {
+            self.names
+                .iter()
+                .filter(|(candidate, _)| candidate.eq_ignore_ascii_case(name))
+                .map(|(_, no)| *no)
+                .min()
+        })
+    }
+}

--- a/crates/siglus_scene_vm/src/runtime/tables.rs
+++ b/crates/siglus_scene_vm/src/runtime/tables.rs
@@ -5,6 +5,7 @@
 //!
 //! NOTE: `TCHAR` in the original engine is UTF-16LE.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use siglus_assets::{
@@ -981,9 +982,11 @@ fn nested_indexed_field_unquoted<'a>(
     None
 }
 
-fn raw_gameexe_field(raw_text: Option<&str>, key: &str) -> Option<String> {
-    let text = raw_text?;
-    for line in text.lines() {
+type RawGameexeFields<'a> = HashMap<String, &'a str>;
+
+fn index_raw_gameexe_fields(raw_text: Option<&str>) -> RawGameexeFields<'_> {
+    let mut fields = HashMap::new();
+    for line in raw_text.unwrap_or_default().lines() {
         let mut s = line.trim();
         if s.is_empty() {
             continue;
@@ -997,17 +1000,23 @@ fn raw_gameexe_field(raw_text: Option<&str>, key: &str) -> Option<String> {
         let Some((lhs, rhs)) = s.split_once('=') else {
             continue;
         };
-        if normalize_gameexe_key(lhs) != normalize_gameexe_key(key) {
-            continue;
-        }
         let v = rhs.trim();
-        return Some(v.trim().trim_end_matches(';').trim().to_string());
+        // Preserve the raw lookup's first-match policy and quoting. Normalizing
+        // every line again for every missing WAKU button field made debug
+        // startup spend minutes rescanning the same configuration.
+        fields
+            .entry(normalize_gameexe_key(lhs))
+            .or_insert(v.trim_end_matches(';').trim());
     }
-    None
+    fields
+}
+
+fn raw_gameexe_field(fields: &RawGameexeFields<'_>, key: &str) -> Option<String> {
+    fields.get(&normalize_gameexe_key(key)).map(|value| (*value).to_string())
 }
 
 fn raw_nested_indexed_field(
-    raw_text: Option<&str>,
+    fields: &RawGameexeFields<'_>,
     prefix: &str,
     index: usize,
     nested: &str,
@@ -1020,7 +1029,7 @@ fn raw_nested_indexed_field(
         format!("{prefix}.{index}.{nested}.{nested_index:03}.{field}"),
         format!("{prefix}.{index:03}.{nested}.{nested_index:03}.{field}"),
     ] {
-        if let Some(v) = raw_gameexe_field(raw_text, &key) {
+        if let Some(v) = raw_gameexe_field(fields, &key) {
             return Some(v);
         }
     }
@@ -1028,7 +1037,7 @@ fn raw_nested_indexed_field(
 }
 
 fn raw_indexed_field(
-    raw_text: Option<&str>,
+    fields: &RawGameexeFields<'_>,
     prefix: &str,
     index: usize,
     field: &str,
@@ -1037,7 +1046,7 @@ fn raw_indexed_field(
         format!("{prefix}.{index}.{field}"),
         format!("{prefix}.{index:03}.{field}"),
     ] {
-        if let Some(v) = raw_gameexe_field(raw_text, &key) {
+        if let Some(v) = raw_gameexe_field(fields, &key) {
             return Some(v);
         }
     }
@@ -1046,6 +1055,42 @@ fn raw_indexed_field(
 
 fn trim_gameexe_scalar(raw: &str) -> &str {
     raw.trim().trim_matches('"')
+}
+
+#[cfg(test)]
+mod raw_gameexe_tests {
+    use super::*;
+
+    #[test]
+    fn raw_index_preserves_first_match_and_quoted_values() {
+        let text = "\u{feff} # waku . 000 . waku_file = \"a,b=c\" ;\n\
+                    #WAKU.000.WAKU_FILE = \"later\"\n\
+                    malformed line\n";
+        let fields = index_raw_gameexe_fields(Some(text));
+        assert_eq!(
+            raw_indexed_field(&fields, "WAKU", 0, "WAKU_FILE").as_deref(),
+            Some("\"a,b=c\"")
+        );
+        assert!(raw_indexed_field(&fields, "WAKU", 1, "WAKU_FILE").is_none());
+        assert!(index_raw_gameexe_fields(None).is_empty());
+    }
+
+    #[test]
+    fn raw_index_keeps_unpadded_then_padded_lookup_precedence() {
+        let fields = index_raw_gameexe_fields(Some(
+            "#WAKU.001.BTN.002.FILE = \"padded\"\n\
+             #WAKU.1.BTN.2.FILE = \"plain\"\n\
+             #WAKU.001.BTN.003.FILE = \"only padded\"\n",
+        ));
+        assert_eq!(
+            raw_nested_indexed_field(&fields, "WAKU", 1, "BTN", 2, "FILE").as_deref(),
+            Some("\"plain\"")
+        );
+        assert_eq!(
+            raw_nested_indexed_field(&fields, "WAKU", 1, "BTN", 3, "FILE").as_deref(),
+            Some("\"only padded\"")
+        );
+    }
 }
 
 fn parse_waku_button_type(raw: &str, button: &mut WakuButtonTemplate) {
@@ -1112,6 +1157,7 @@ fn parse_waku_button_type(raw: &str, button: &mut WakuButtonTemplate) {
 }
 
 fn load_waku_templates(cfg: &GameexeConfig, raw_text: Option<&str>) -> Vec<WakuTemplate> {
+    let raw_fields = index_raw_gameexe_fields(raw_text);
     let cnt = cfg
         .get_usize("WAKU.CNT")
         .unwrap_or(INIDEF_WAKU_CNT)
@@ -1135,7 +1181,7 @@ fn load_waku_templates(cfg: &GameexeConfig, raw_text: Option<&str>) -> Vec<WakuT
         t.buttons = vec![WakuButtonTemplate::default(); btn_cnt];
         t.face_pos = vec![(0, 0); face_cnt];
         t.object_cnt = object_cnt;
-        let raw_top = |field: &str| raw_indexed_field(raw_text, "WAKU", i, field);
+        let raw_top = |field: &str| raw_indexed_field(&raw_fields, "WAKU", i, field);
 
         let extend_type_raw = raw_top("EXTEND_TYPE");
         if let Some(v) = extend_type_raw
@@ -1251,7 +1297,7 @@ fn load_waku_templates(cfg: &GameexeConfig, raw_text: Option<&str>) -> Vec<WakuT
         for btn_idx in 0..t.buttons.len() {
             let mut b = WakuButtonTemplate::default();
 
-            let file_raw = raw_nested_indexed_field(raw_text, "WAKU", i, "BTN", btn_idx, "FILE");
+            let file_raw = raw_nested_indexed_field(&raw_fields, "WAKU", i, "BTN", btn_idx, "FILE");
             if let Some(v) = file_raw
                 .as_deref()
                 .or_else(|| nested_indexed_field_unquoted(cfg, "WAKU", i, "BTN", btn_idx, "FILE"))
@@ -1259,7 +1305,7 @@ fn load_waku_templates(cfg: &GameexeConfig, raw_text: Option<&str>) -> Vec<WakuT
                 b.file_name = trim_gameexe_scalar(v).to_string();
             }
 
-            let cut_raw = raw_nested_indexed_field(raw_text, "WAKU", i, "BTN", btn_idx, "CUT_NO");
+            let cut_raw = raw_nested_indexed_field(&raw_fields, "WAKU", i, "BTN", btn_idx, "CUT_NO");
             if let Some(v) = cut_raw
                 .as_deref()
                 .or_else(|| nested_indexed_field(cfg, "WAKU", i, "BTN", btn_idx, "CUT_NO"))
@@ -1268,7 +1314,7 @@ fn load_waku_templates(cfg: &GameexeConfig, raw_text: Option<&str>) -> Vec<WakuT
                 b.cut_no = v;
             }
 
-            let pos_raw = raw_nested_indexed_field(raw_text, "WAKU", i, "BTN", btn_idx, "POS");
+            let pos_raw = raw_nested_indexed_field(&raw_fields, "WAKU", i, "BTN", btn_idx, "POS");
             let pos = parse_i64_tuple(
                 pos_raw
                     .as_deref()
@@ -1282,7 +1328,7 @@ fn load_waku_templates(cfg: &GameexeConfig, raw_text: Option<&str>) -> Vec<WakuT
             }
 
             let action_raw =
-                raw_nested_indexed_field(raw_text, "WAKU", i, "BTN", btn_idx, "ACTION");
+                raw_nested_indexed_field(&raw_fields, "WAKU", i, "BTN", btn_idx, "ACTION");
             if let Some(v) = action_raw
                 .as_deref()
                 .or_else(|| nested_indexed_field(cfg, "WAKU", i, "BTN", btn_idx, "ACTION"))
@@ -1291,7 +1337,7 @@ fn load_waku_templates(cfg: &GameexeConfig, raw_text: Option<&str>) -> Vec<WakuT
                 b.action_no = v;
             }
 
-            let se_raw = raw_nested_indexed_field(raw_text, "WAKU", i, "BTN", btn_idx, "SE");
+            let se_raw = raw_nested_indexed_field(&raw_fields, "WAKU", i, "BTN", btn_idx, "SE");
             if let Some(v) = se_raw
                 .as_deref()
                 .or_else(|| nested_indexed_field(cfg, "WAKU", i, "BTN", btn_idx, "SE"))
@@ -1300,7 +1346,7 @@ fn load_waku_templates(cfg: &GameexeConfig, raw_text: Option<&str>) -> Vec<WakuT
                 b.se_no = v;
             }
 
-            let type_raw = raw_nested_indexed_field(raw_text, "WAKU", i, "BTN", btn_idx, "TYPE");
+            let type_raw = raw_nested_indexed_field(&raw_fields, "WAKU", i, "BTN", btn_idx, "TYPE");
             if let Some(v) = type_raw
                 .as_deref()
                 .or_else(|| nested_indexed_field_unquoted(cfg, "WAKU", i, "BTN", btn_idx, "TYPE"))
@@ -1308,7 +1354,7 @@ fn load_waku_templates(cfg: &GameexeConfig, raw_text: Option<&str>) -> Vec<WakuT
                 parse_waku_button_type(v, &mut b);
             }
 
-            let call_raw = raw_nested_indexed_field(raw_text, "WAKU", i, "BTN", btn_idx, "CALL");
+            let call_raw = raw_nested_indexed_field(&raw_fields, "WAKU", i, "BTN", btn_idx, "CALL");
             if let Some(v) = call_raw
                 .as_deref()
                 .or_else(|| nested_indexed_field_unquoted(cfg, "WAKU", i, "BTN", btn_idx, "CALL"))
@@ -1325,7 +1371,7 @@ fn load_waku_templates(cfg: &GameexeConfig, raw_text: Option<&str>) -> Vec<WakuT
             }
 
             let frame_action_raw =
-                raw_nested_indexed_field(raw_text, "WAKU", i, "BTN", btn_idx, "FRAME_ACTION");
+                raw_nested_indexed_field(&raw_fields, "WAKU", i, "BTN", btn_idx, "FRAME_ACTION");
             if let Some(v) = frame_action_raw.as_deref().or_else(|| {
                 nested_indexed_field_unquoted(cfg, "WAKU", i, "BTN", btn_idx, "FRAME_ACTION")
             }) {
@@ -1347,7 +1393,7 @@ fn load_waku_templates(cfg: &GameexeConfig, raw_text: Option<&str>) -> Vec<WakuT
         }
 
         for face_idx in 0..t.face_pos.len() {
-            let pos_raw = raw_nested_indexed_field(raw_text, "WAKU", i, "FACE", face_idx, "POS");
+            let pos_raw = raw_nested_indexed_field(&raw_fields, "WAKU", i, "FACE", face_idx, "POS");
             let pos = parse_i64_tuple(
                 pos_raw
                     .as_deref()

--- a/crates/siglus_scene_vm/src/runtime/ui.rs
+++ b/crates/siglus_scene_vm/src/runtime/ui.rs
@@ -1,5 +1,8 @@
 //! Message-window rendering state projected from runtime MWND state.
 
+#[cfg(test)]
+mod glyph_cache_tests;
+
 use crate::image_manager::ImageId;
 use crate::layer::{LayerId, Sprite, SpriteFit, SpriteId, SpriteSizeMode};
 use crate::runtime::globals::{EditBoxListState, ScriptRuntimeState, SyscomRuntimeState};
@@ -91,6 +94,9 @@ pub struct MwndGlyphLayerRuntime {
     pub shadow_offset: (i32, i32),
     pub fuchi_offset: (i32, i32),
     pub body_offset: (i32, i32),
+    /// Raster inputs exclude sprite position/alpha/reveal state. Frame actions
+    /// can re-project identical text without changing any texture pixels.
+    rasterized_glyph: Option<PositionedTextGlyph>,
 }
 
 #[derive(Debug, Default)]
@@ -1801,15 +1807,15 @@ impl UiRuntime {
         };
         let normalized_font_name = crate::text_render::normalized_font_name(font_name);
         let request_changed = self.font_cache.requested_name() != normalized_font_name.as_str();
+        let font_was_loaded = self.font_cache.is_loaded();
         let _ = self
             .font_cache
             .load_for_project_named(project_dir, font_name);
-        if request_changed {
+        if request_changed || (!font_was_loaded && self.font_cache.is_loaded()) {
             // The original clears G_moji_manager when the effective font
             // changes.  This UI path is atlas-like, so invalidate its baked
             // images at the same boundary.
-            self.mwnd.msg.text_dirty = true;
-            self.mwnd.name.text_dirty = true;
+            self.invalidate_mwnd_text_images();
         }
         self.refresh_waku_images(images, project_dir);
         self.refresh_face_image(images, project_dir);
@@ -3055,6 +3061,16 @@ impl UiRuntime {
         }
     }
 
+    fn invalidate_mwnd_text_images(&mut self) {
+        self.mwnd.msg.text_dirty = true;
+        self.mwnd.name.text_dirty = true;
+        for runtime in self.mwnd.msg.glyph_layers.iter_mut()
+            .chain(self.mwnd.name.glyph_layers.iter_mut())
+        {
+            runtime.rasterized_glyph = None;
+        }
+    }
+
     fn refresh_projected_glyph_layers(
         font_cache: &crate::text_render::FontCache,
         images: &mut crate::image_manager::ImageManager,
@@ -3076,6 +3092,7 @@ impl UiRuntime {
                 runtime.shadow_offset = (0, 0);
                 runtime.fuchi_offset = (0, 0);
                 runtime.body_offset = (0, 0);
+                runtime.rasterized_glyph = None;
                 continue;
             };
 
@@ -3096,6 +3113,10 @@ impl UiRuntime {
                     bold: glyph.bold,
                 },
             };
+
+            if runtime.rasterized_glyph == Some(positioned) {
+                continue;
+            }
 
             if glyph.shadow {
                 if let Some(render) = font_cache.render_single_glyph_layer_into(
@@ -3145,6 +3166,7 @@ impl UiRuntime {
                 runtime.body_image = None;
                 runtime.body_offset = (0, 0);
             }
+            runtime.rasterized_glyph = Some(positioned);
         }
     }
 

--- a/crates/siglus_scene_vm/src/runtime/ui/glyph_cache_tests.rs
+++ b/crates/siglus_scene_vm/src/runtime/ui/glyph_cache_tests.rs
@@ -1,0 +1,135 @@
+use super::*;
+use crate::image_manager::ImageManager;
+
+fn glyph() -> MwndGlyphProjection {
+    MwndGlyphProjection {
+        moji_type: 0,
+        code: 65,
+        ch: 'A',
+        x: 0,
+        y: 0,
+        size: 24,
+        color: (240, 220, 200),
+        shadow_color: (10, 20, 30),
+        fuchi_color: (80, 60, 40),
+        shadow_mode: 3,
+        shadow: true,
+        fuchi: true,
+        bold: false,
+        reveal_index: 0,
+        ruby: false,
+        appeared: true,
+        emoji_file: None,
+        emoji_font_size: 0,
+        message_button: None,
+    }
+}
+
+fn font() -> FontCache {
+    let mut font = FontCache::new();
+    assert!(font.load_from_font_dir(&Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/fonts")));
+    font
+}
+
+#[test]
+fn repeated_projection_and_reveal_do_not_rasterize_or_reupload_glyphs() {
+    let font = font();
+    let mut images = ImageManager::new(PathBuf::new());
+    let mut runtimes = Vec::new();
+    let mut glyph = glyph();
+    UiRuntime::refresh_projected_glyph_layers(
+        &font,
+        &mut images,
+        &[glyph.clone()],
+        &mut runtimes,
+        false,
+    );
+    let ids = [
+        runtimes[0].shadow_image.unwrap(),
+        runtimes[0].fuchi_image.unwrap(),
+        runtimes[0].body_image.unwrap(),
+    ];
+    let before: Vec<_> = ids
+        .iter()
+        .map(|&id| {
+            let (img, version) = images.get_entry(id).unwrap();
+            (std::sync::Arc::clone(img), version)
+        })
+        .collect();
+    glyph.x = 100;
+    glyph.y = 200;
+    glyph.appeared = false;
+    glyph.reveal_index = 9;
+    for _ in 0..10 {
+        UiRuntime::refresh_projected_glyph_layers(
+            &font,
+            &mut images,
+            &[glyph.clone()],
+            &mut runtimes,
+            false,
+        );
+    }
+    for (id, (pixels, version)) in ids.into_iter().zip(before) {
+        let (actual, actual_version) = images.get_entry(id).unwrap();
+        assert_eq!(actual_version, version);
+        assert!(std::sync::Arc::ptr_eq(actual, &pixels));
+    }
+
+    // Every raster input invalidates the cache, not just character identity.
+    for change in 0..10 {
+        let id = runtimes[0].body_image.unwrap();
+        let before_version = images.get_entry(id).unwrap().1;
+        match change {
+            0 => glyph.ch = 'B',
+            1 => glyph.size += 3,
+            2 => glyph.color.0 -= 1,
+            3 => glyph.shadow_color.0 += 1,
+            4 => glyph.fuchi_color.0 += 1,
+            5 => glyph.shadow_mode = 2,
+            6 => glyph.shadow = false,
+            7 => glyph.fuchi = false,
+            8 => glyph.bold = true,
+            _ => {}
+        }
+        UiRuntime::refresh_projected_glyph_layers(
+            &font,
+            &mut images,
+            &[glyph.clone()],
+            &mut runtimes,
+            change == 9,
+        );
+        assert!(
+            images.get_entry(id).unwrap().1 > before_version,
+            "input {change}"
+        );
+    }
+    UiRuntime::refresh_projected_glyph_layers(&font, &mut images, &[], &mut runtimes, false);
+    assert!(runtimes[0].source_index.is_none());
+    assert!(runtimes[0].body_image.is_none());
+    assert!(runtimes[0].rasterized_glyph.is_none());
+    UiRuntime::refresh_projected_glyph_layers(&font, &mut images, &[glyph], &mut runtimes, false);
+    assert!(runtimes[0].body_image.is_some());
+}
+
+#[test]
+fn font_invalidation_refreshes_both_message_and_name_glyphs() {
+    let mut ui = UiRuntime::default();
+    ui.font_cache = font();
+    let mut images = ImageManager::new(PathBuf::new());
+    ui.mwnd.msg.glyphs = vec![glyph()];
+    ui.mwnd.name.glyphs = vec![glyph()];
+    ui.invalidate_mwnd_text_images();
+    ui.refresh_text_images(&mut images, 1920, 1080);
+    let ids = [
+        ui.mwnd.msg.glyph_layers[0].body_image.unwrap(),
+        ui.mwnd.name.glyph_layers[0].body_image.unwrap(),
+    ];
+    let versions = ids.map(|id| images.get_entry(id).unwrap().1);
+    ui.invalidate_mwnd_text_images();
+    assert!(ui.mwnd.msg.glyph_layers[0].rasterized_glyph.is_none());
+    assert!(ui.mwnd.name.glyph_layers[0].rasterized_glyph.is_none());
+    ui.refresh_text_images(&mut images, 1920, 1080);
+    for (id, version) in ids.into_iter().zip(versions) {
+        assert!(images.get_entry(id).unwrap().1 > version);
+    }
+}

--- a/crates/siglus_scene_vm/src/scene_stream.rs
+++ b/crates/siglus_scene_vm/src/scene_stream.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, bail, Result};
+use std::sync::Arc;
 
 use siglus_assets::scene_pck::CIndex;
 
@@ -175,9 +176,11 @@ pub struct SceneStream<'a> {
     pub str_list: &'a [u8],
     pub label_list: &'a [u8],
     pub z_label_list: &'a [u8],
-    pub scn_prop_name_map: std::collections::HashMap<u32, String>,
-    pub scn_cmd_name_map: std::collections::HashMap<u32, String>,
-    pub call_prop_name_map: std::collections::HashMap<u32, String>,
+    // Name tables belong to the immutable scene, not to its execution cursor.
+    // Calls, frame callbacks and save checkpoints only need to share them.
+    pub scn_prop_name_map: Arc<std::collections::HashMap<u32, String>>,
+    pub scn_cmd_name_map: Arc<std::collections::HashMap<u32, String>>,
+    pub call_prop_name_map: Arc<std::collections::HashMap<u32, String>>,
     pub pc: usize,
 }
 
@@ -257,9 +260,9 @@ impl<'a> SceneStream<'a> {
             str_list,
             label_list,
             z_label_list,
-            scn_prop_name_map,
-            scn_cmd_name_map,
-            call_prop_name_map,
+            scn_prop_name_map: Arc::new(scn_prop_name_map),
+            scn_cmd_name_map: Arc::new(scn_cmd_name_map),
+            call_prop_name_map: Arc::new(call_prop_name_map),
             pc: 0,
         })
     }

--- a/crates/siglus_scene_vm/src/text_render.rs
+++ b/crates/siglus_scene_vm/src/text_render.rs
@@ -42,7 +42,7 @@ pub fn font_shadow_mode_flags(mode: i64) -> (bool, bool) {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TextStyle {
     pub color: (u8, u8, u8),
     pub shadow_color: (u8, u8, u8),
@@ -62,7 +62,7 @@ pub enum TextSpriteLayer {
     Body,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PositionedTextGlyph {
     pub ch: char,
     pub x: i32,
@@ -1871,9 +1871,12 @@ fn blend_rgba_pixel(
     sa: u8,
 ) {
     let idx = ((y * w + x) * 4) as usize;
-    let da = rgba[idx + 3] as u16;
-    let sa_u = sa as u16;
-    let inv_sa = 255u16.saturating_sub(sa_u);
+    // The destination term multiplies three byte-sized factors before dividing
+    // by 255. Its intermediate can reach 255^3, so u16 would overflow for
+    // ordinary coloured glyph/outline overlaps (and panic in debug builds).
+    let da = rgba[idx + 3] as u32;
+    let sa_u = sa as u32;
+    let inv_sa = 255u32.saturating_sub(sa_u);
     // Cfont_copy's alpha table uses integer truncation:
     //   src + dst - src * dst / 255
     // Do not round here; repeated face copies otherwise diverge from tona3.
@@ -1886,8 +1889,8 @@ fn blend_rgba_pixel(
         return;
     }
     let blend = |src: u8, dst: u8| -> u8 {
-        let src_p = src as u16 * sa_u;
-        let dst_p = dst as u16 * da * inv_sa / 255;
+        let src_p = src as u32 * sa_u;
+        let dst_p = dst as u32 * da * inv_sa / 255;
         ((src_p + dst_p + out_a / 2) / out_a).min(255) as u8
     };
     rgba[idx] = blend(sr, rgba[idx]);
@@ -2348,5 +2351,46 @@ mod font_shadow_mode_tests {
         blend_rgba_pixel(&mut rgba, 1, 0, 0, 0, 0, 0, 128);
         blend_rgba_pixel(&mut rgba, 1, 0, 0, 0, 0, 0, 128);
         assert_eq!(rgba[3], 192);
+    }
+
+    #[test]
+    fn coloured_glyph_faces_blend_over_opaque_pixels_without_overflow() {
+        let mut rgba = [255, 220, 192, 255];
+        blend_rgba_pixel(&mut rgba, 1, 0, 0, 80, 160, 240, 128);
+        assert_eq!(rgba, [167, 190, 216, 255]);
+    }
+
+    #[test]
+    fn coloured_glyph_blend_matches_wide_reference_for_all_alpha_pairs() {
+        let source = [80u8, 160, 240];
+        for sa in 0..=255u8 {
+            for da in 0..=255u8 {
+                let destination = [255u8, 129, 37, da];
+                let mut actual = destination;
+                blend_rgba_pixel(&mut actual, 1, 0, 0, source[0], source[1], source[2], sa);
+
+                let source_alpha = u64::from(sa);
+                let destination_alpha = u64::from(da);
+                let alpha =
+                    source_alpha + destination_alpha - source_alpha * destination_alpha / 255;
+                let mut expected = [0u8; 4];
+                if alpha != 0 {
+                    for channel in 0..3 {
+                        let foreground = u64::from(source[channel]) * source_alpha;
+                        let background = u64::from(destination[channel])
+                            * destination_alpha
+                            * (255 - source_alpha)
+                            / 255;
+                        expected[channel] =
+                            ((foreground + background + alpha / 2) / alpha).min(255) as u8;
+                    }
+                    expected[3] = alpha as u8;
+                }
+                assert_eq!(
+                    actual, expected,
+                    "source alpha={sa}, destination alpha={da}"
+                );
+            }
+        }
     }
 }

--- a/crates/siglus_scene_vm/src/vm.rs
+++ b/crates/siglus_scene_vm/src/vm.rs
@@ -1,8 +1,12 @@
 //! Scene VM
 
+#[cfg(test)]
+mod perf_tests;
+
 use anyhow::{anyhow, bail, Result};
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
+use std::sync::Arc;
 
 use crate::elm_code;
 use crate::runtime::forms::codes;
@@ -292,8 +296,8 @@ struct SceneExecFrame<'a> {
     // Only lexer state and scene-local property selection change.  Keep the
     // caller stream by move (not clone) and leave all VM stacks resident.
     stream: SceneStream<'a>,
-    user_cmd_names: std::collections::HashMap<u32, String>,
-    call_cmd_names: std::collections::HashMap<u32, String>,
+    user_cmd_names: Arc<std::collections::HashMap<u32, String>>,
+    call_cmd_names: Arc<std::collections::HashMap<u32, String>>,
     current_scene_no: Option<usize>,
     current_scene_name: Option<String>,
     current_line_no: i32,
@@ -366,8 +370,8 @@ fn resize_string_vec(mut v: Vec<String>, n: usize) -> Vec<String> {
 #[derive(Clone)]
 struct VmResumePoint<'a> {
     stream: SceneStream<'a>,
-    user_cmd_names: std::collections::HashMap<u32, String>,
-    call_cmd_names: std::collections::HashMap<u32, String>,
+    user_cmd_names: Arc<std::collections::HashMap<u32, String>>,
+    call_cmd_names: Arc<std::collections::HashMap<u32, String>>,
     int_stack: Vec<i32>,
     str_stack: Vec<String>,
     element_points: Vec<usize>,
@@ -425,8 +429,8 @@ pub struct SceneVm<'a> {
     script_input_synced_this_frame: bool,
     yield_safe_after_step: bool,
 
-    user_cmd_names: std::collections::HashMap<u32, String>,
-    call_cmd_names: std::collections::HashMap<u32, String>,
+    user_cmd_names: Arc<std::collections::HashMap<u32, String>>,
+    call_cmd_names: Arc<std::collections::HashMap<u32, String>>,
 
     // C++ keeps the lexer / scene package resident. Do not reload and rebuild
     // Scene.pck for frame-action callbacks or scene-local user command calls.
@@ -732,7 +736,7 @@ impl<'a> SceneVm<'a> {
             script_input_synced_this_frame: false,
             yield_safe_after_step: false,
             user_cmd_names,
-            call_cmd_names: std::collections::HashMap::new(),
+            call_cmd_names: Arc::default(),
             scene_pck_cache: None,
             scene_stream_cache: BTreeMap::new(),
             scene_name_resolve_cache: std::collections::HashMap::new(),
@@ -791,7 +795,7 @@ impl<'a> SceneVm<'a> {
             script_input_synced_this_frame: false,
             yield_safe_after_step: false,
             user_cmd_names,
-            call_cmd_names: std::collections::HashMap::new(),
+            call_cmd_names: Arc::default(),
             scene_pck_cache: None,
             scene_stream_cache: BTreeMap::new(),
             scene_name_resolve_cache: std::collections::HashMap::new(),
@@ -1673,6 +1677,9 @@ impl<'a> SceneVm<'a> {
                 let opt = ScenePckDecodeOptions::from_project_dir(&self.ctx.project_dir)?;
                 self.scene_pck_cache = Some(ScenePck::load_and_rebuild(&scene_pck_path, &opt)?);
             }
+            self.ctx.install_scene_metadata(
+                self.scene_pck_cache.as_ref().expect("scene pck cache initialized"),
+            )?;
         }
         Ok(())
     }

--- a/crates/siglus_scene_vm/src/vm/perf_tests.rs
+++ b/crates/siglus_scene_vm/src/vm/perf_tests.rs
@@ -1,0 +1,41 @@
+use super::*;
+
+#[test]
+fn scene_cursors_and_savepoints_share_names_but_keep_independent_execution_state() {
+    let mut chunk = vec![0; 132 + 32];
+    chunk[4..8].copy_from_slice(&132i32.to_le_bytes());
+    chunk[8..12].copy_from_slice(&32i32.to_le_bytes());
+    let mut stream = SceneStream::new(&chunk).unwrap();
+    Arc::make_mut(&mut stream.scn_cmd_name_map).insert(0, "scene_command".into());
+    Arc::make_mut(&mut stream.scn_prop_name_map).insert(1, "scene_property".into());
+    Arc::make_mut(&mut stream.call_prop_name_map).insert(2, "call_property".into());
+    let cursor = stream.clone();
+    assert!(Arc::ptr_eq(&stream.scn_cmd_name_map, &cursor.scn_cmd_name_map));
+    assert!(Arc::ptr_eq(&stream.scn_prop_name_map, &cursor.scn_prop_name_map));
+    assert!(Arc::ptr_eq(&stream.call_prop_name_map, &cursor.call_prop_name_map));
+    stream.set_prg_cntr(17).unwrap();
+    assert_eq!(cursor.pc, 0);
+
+    let ctx = CommandContext::new(std::env::temp_dir().join("siglus-metadata-unit-test"));
+    let mut vm = SceneVm::new(stream, ctx);
+    Arc::make_mut(&mut vm.call_cmd_names).insert(3, "include_command".into());
+    vm.int_stack.push(7);
+    let names = vm.user_cmd_names.clone();
+    let include_names = vm.call_cmd_names.clone();
+    let resume = vm.make_resume_point();
+    assert!(Arc::ptr_eq(&names, &vm.stream.scn_cmd_name_map));
+    assert!(Arc::ptr_eq(&names, &resume.user_cmd_names));
+    assert!(Arc::ptr_eq(&include_names, &resume.call_cmd_names));
+
+    vm.user_cmd_names = Arc::default();
+    vm.call_cmd_names = Arc::default();
+    vm.stream.pc = 0;
+    vm.int_stack.push(8);
+    vm.restore_resume_point(resume);
+    assert!(Arc::ptr_eq(&names, &vm.user_cmd_names));
+    assert!(Arc::ptr_eq(&include_names, &vm.call_cmd_names));
+    assert_eq!(vm.stream.pc, 17);
+    assert_eq!(vm.int_stack, vec![7]);
+    assert_eq!(vm.user_cmd_names[&0], "scene_command");
+    assert_eq!(vm.call_cmd_names[&3], "include_command");
+}


### PR DESCRIPTION
## Summary

Port the portable startup/save compatibility fixes and runtime stall reductions from downstream testing of Summer Pockets REFLECTION BLUE onto the current upstream `main`.

This is a clean branch based on `f4e1262ed0ee08e6508268d4e6334ca5046826bc`, not a merge of the long-lived integration branch. It preserves upstream's current VM frame/state handling and tracing implementation.

### Compatibility

- Accept ASCII case-insensitive scene-name lookup after trying an exact match, with deterministic fallback selection.
- Preserve indexed Gameexe lookup precedence while normalizing the query once and indexing raw WAKU configuration once.
- Read the global character-voice flag with its one-byte serialized width, keeping subsequent save fields aligned.
- Use wider intermediate arithmetic when blending coloured glyphs to prevent debug overflow and incorrect pixels.

### Runtime work reduction

- Share immutable scene command-name maps across cursors and resume points with `Arc`; keep execution cursors independent.
- Cache scene names/read-flag counts and reuse them for scene lookup and global save/read operations.
- Reuse glyph rasterization when its inputs have not changed, while invalidating on font, layout, or style changes.
- Batch GPU mipmap generation before the rendering commands that consume it, matching the existing byte-space box filter, including odd-sized textures and alpha.
- Speed up overlapping G00 LZSS copies and decode type-0 data directly into RGBA.
- Stream native BGM through Kira instead of decoding the complete track before playback; keep the static Web fallback, sample-based loop boundaries, and safe stop/reset/drop ordering.
- Retain a bounded movie-preview pixel cache (8 entries / 32 MiB) across scene restarts, without retaining active playback handles or image IDs.

## Validation

- `cargo test -p siglus_assets -p siglus_scene_vm --lib --target aarch64-apple-darwin --offline -- --test-threads=1 --nocapture`: **107 passed** (13 assets + 94 runtime tests).
  - The GPU mipmap pixel comparison ran on an Apple M1 Pro; it was not skipped.
  - Includes overlapping LZSS copies, glyph alpha arithmetic/cache invalidation, configuration precedence, scene/save metadata, shared cursor maps, preview eviction, and BGM loop/lifecycle tests.
- `cargo check -p siglus_scene_vm --lib --target wasm32-unknown-unknown --locked`: **passed**.
- `cargo build -p siglus_scene_vm --bin siglus_engine --target aarch64-apple-darwin --locked`: **passed** (macOS Debug standalone engine).
- `git diff --check`: **passed**.
- `cargo check --workspace --all-targets --target aarch64-apple-darwin --locked` is blocked by an existing error in the unchanged upstream `shion-xfile` tests: `crates/shion-xfile/src/semantic.rs:1519` calls `parse_x` without importing it (`E0425`). The same code is present in the base commit; this PR does not modify that crate.

The originating downstream macOS Debug changes were exercised through loading the first save, advancing dialogue 30 times, returning to the title, and loading again. That is context for the fixes, not a benchmark of this upstream port or a claim that every frame is below 50 ms; cold image decoding still has remaining spikes. The tests/builds above are the validation performed on this exact upstream port.

## Scope

No new dependencies, workflow changes, game data, keys, saves, local profiling artifacts, private-package code, or downstream integration/FFI layer are included. This PR only changes the public Rust assets/runtime implementation and synthetic tests. Existing upstream CI may publish its usual public engine build artifacts; no private package is involved.
